### PR TITLE
Fixes # 6 - Extract rainfall distribution curve number 

### DIFF
--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -96,4 +96,4 @@ def rainfallDistributionCurve(lat, lon):
     elif rainfall_distribution_curve_letter == "D":
         rainfall_distribution_curve_number = 7
 
-    return rainfall_distribution_curve_number
+    return rainfall_distribution_curve_letter, rainfall_distribution_curve_number

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -26,17 +26,16 @@ def rainfallData(lat, lon):
     results_1hr = results[4]
     results_2hr = results[5]
     results_3hr = results[6]
-    results_6hr = results[7]
-    results_12hr = results[8]
-    results_24hr = results[9]
-
-    # Save values of interest: these values coorespond to Names in the Spreadsheet for the SC Synethic Unit Hydrograph Method
-    # Variable naming schema: ex. P50_12 refers to the precipitation frequency estimate (inches) for 12-hour storms with an average recurrence interval of 50 years (AEP 2%)
-    P10_1 = results_1hr[3]
-    P10_2 = results_2hr[3]
-    P10_3 = results_3hr[3]
-    P10_6 = results_6hr[3]
-    P10_12 = results_12hr[3]
+    results_6hr = reults[7]
+    results_12hr = rsults[8]
+    results_24hr = rsults[9]
+    # Save values ofinterest: these values coorespond to Names in the Spreadsheet for the SC Synethic Unit Hydrograph Method
+    # Variable namin schema: ex. P50_12 refers to the precipitation frequency estimate (inches) for 12-hour storms with an average recurrence interval of 50 years (AEP 2%)
+    P10_1 = results_hr[3]
+    P10_2 = results_hr[3]
+    P10_3 = results_hr[3]
+    P10_6 = results_hr[3]
+    P10_12 = results12hr[3]
     P10_24 = results_24hr[3]
     
     P25_1 = results_1hr[4]
@@ -71,5 +70,30 @@ def rainfallData(lat, lon):
 
     return P10_1,P10_2,P10_3,P10_6,P10_12,P10_24,P25_1,P25_2,P25_3,P25_6,P25_12,P25_24,P50_1,P50_2,P50_3,P50_6,P50_12,P50_24,P100_1,P100_2,P100_3,P100_6,P100_12,P100_24,P2_24_1,P2_24_2,P2_24_5,P2_24_10,P2_24_25,P2_24_50,P2_24_100
 
+# Retrieve the rainfall distribution curve number from the NOAA Atlas 14 Rainfall Distributions
+# The available rainfall distribution curve letters in this map service are NOAA A, NOAA B, NOAA C, and NOAA D
+# Note: Type II and Type II Rainfall Distribution Curves are also possible but will be provided as a manual selection option in the user interface
 def rainfallDistributionCurve(lat, lon): 
-    return "Hello, World! from rainfallDistributionCurve"
+
+    # Use map service to query the coordinate point with the NOAA Atlast 14 rainfall distributions map service
+    requestURL = "https://gis.streamstats.usgs.gov/arcgis/rest/services/runoffmodeling/SC_rainfallcurve/MapServer/0/query?geometry={}%2C{}&geometryType=esriGeometryPoint&returnGeometry=false&f=pjson".format(lon,lat)
+    response = requests.get(requestURL)
+    if response.status_code != 200:
+        raise Exception("Request to rainfall distribution curve map servivce failed")
+
+    # Extract the NOAA rainfall distribution curve letter from the map service response
+    response_content = response.json()
+    rainfall_distribution_curve_letter = response_content["features"][0]["attributes"]["Rf_Dist"]
+    
+    # Translate the NOAA rainfall distribution curve letter to the rainfall distribution curve number used in the SC Synthetic UH Method spreadsheet
+    # Note: Type II = 2 and Type III = 3 are two other options, but these will be provided as a manual selection option in the user interface
+    if rainfall_distribution_curve_letter == "A":
+        rainfall_distribution_curve_number = 4
+    elif rainfall_distribution_curve_letter == "B":
+        rainfall_distribution_curve_number = 5
+    elif rainfall_distribution_curve_letter == "C":
+        rainfall_distribution_curve_number = 6
+    elif rainfall_distribution_curve_letter == "D":
+        rainfall_distribution_curve_number = 7
+
+    return rainfall_distribution_curve_number

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -2,7 +2,7 @@ import requests
 import ast
 
 def curveNumber(lat, lon):
-    return "Hello, World!"
+    return "Hello, World! from curveNumber"
 
 # Retrieve rainfall data from the NOAA Precipitation Frequency Data Server
 # https://hdsc.nws.noaa.gov/hdsc/pfds/pfds_map_cont.html?bkmrk=sc
@@ -69,4 +69,7 @@ def rainfallData(lat, lon):
     P2_24_50 = results_24hr[5]
     P2_24_100 = results_24hr[6]
 
-    return P10_1,P10_2,P10_3,P10_6,P10_12,P10_24,P25_1,P25_2,P25_3,P25_6,P25_12,P25_24,P50_1,P50_2,P50_3,P50_6,P50_12,P50_24,P100_1,P100_2,P100_3,P100_6,P100_12,P100_24,P2_24_1,P2_24_2,P2_24_5,P2_24_10,P2_24_25,P2_24_50,P2_24_100 
+    return P10_1,P10_2,P10_3,P10_6,P10_12,P10_24,P25_1,P25_2,P25_3,P25_6,P25_12,P25_24,P50_1,P50_2,P50_3,P50_6,P50_12,P50_24,P100_1,P100_2,P100_3,P100_6,P100_12,P100_24,P2_24_1,P2_24_2,P2_24_5,P2_24_10,P2_24_25,P2_24_50,P2_24_100
+
+def rainfallDistributionCurve(lat, lon): 
+    return "Hello, World! from rainfallDistributionCurve"

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -29,8 +29,8 @@ def rainfallData(lat, lon):
     results_6hr = results[7]
     results_12hr = results[8]
     results_24hr = results[9]
-    # Save values ofinterest: these values coorespond to Names in the Spreadsheet for the SC Synethic Unit Hydrograph Method
-    # Variable namin schema: ex. P50_12 refers to the precipitation frequency estimate (inches) for 12-hour storms with an average recurrence interval of 50 years (AEP 2%)
+    # Save values of interest: these values coorespond to Names in the Spreadsheet for the SC Synethic Unit Hydrograph Method
+    # Variable naming schema: ex. P50_12 refers to the precipitation frequency estimate (inches) for 12-hour storms with an average recurrence interval of 50 years (AEP 2%)
     P10_1 = results_1hr[3]
     P10_2 = results_2hr[3]
     P10_3 = results_3hr[3]

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -2,7 +2,7 @@ import requests
 import ast
 
 def curveNumber(lat, lon):
-    return "Hello, World! from curveNumber"
+    return "Hello, World!"
 
 # Retrieve rainfall data from the NOAA Precipitation Frequency Data Server
 # https://hdsc.nws.noaa.gov/hdsc/pfds/pfds_map_cont.html?bkmrk=sc
@@ -26,16 +26,16 @@ def rainfallData(lat, lon):
     results_1hr = results[4]
     results_2hr = results[5]
     results_3hr = results[6]
-    results_6hr = reults[7]
-    results_12hr = rsults[8]
-    results_24hr = rsults[9]
+    results_6hr = results[7]
+    results_12hr = results[8]
+    results_24hr = results[9]
     # Save values ofinterest: these values coorespond to Names in the Spreadsheet for the SC Synethic Unit Hydrograph Method
     # Variable namin schema: ex. P50_12 refers to the precipitation frequency estimate (inches) for 12-hour storms with an average recurrence interval of 50 years (AEP 2%)
-    P10_1 = results_hr[3]
-    P10_2 = results_hr[3]
-    P10_3 = results_hr[3]
-    P10_6 = results_hr[3]
-    P10_12 = results12hr[3]
+    P10_1 = results_1hr[3]
+    P10_2 = results_2hr[3]
+    P10_3 = results_3hr[3]
+    P10_6 = results_6hr[3]
+    P10_12 = results_12hr[3]
     P10_24 = results_24hr[3]
     
     P25_1 = results_1hr[4]

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Alternate instructions for the Windows Anaconda3 prompt:
 
 ```bash
 # create a new Conda environment
-conda create --name ss-runoffmodelingservices
+conda create --name sc-runoffmodelingservices
 # active the Conda environment
-conda activate ss-runoffmodelingservices
+conda activate sc-runoffmodelingservices
 # install the project's dependencies
 conda install pip
 pip install -r requirements.txt

--- a/main.py
+++ b/main.py
@@ -148,12 +148,13 @@ def rainfalldata(request_body: RainfallData, response: Response):
 def rainfalldistributioncurve(request_body: RainfallDistributionCurve, response: Response):
 
     try: 
-        response = rainfallDistributionCurve(
+        rainfall_distribution_curve_letter, rainfall_distribution_curve_number = rainfallDistributionCurve(
             request_body.lat,
             request_body.lon
         )
         return {
-            "response": response,
+            "rainfall_distribution_curve_letter": rainfall_distribution_curve_letter,
+            "rainfall_distribution_curve_number": rainfall_distribution_curve_number,
         }
 
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -3,8 +3,7 @@ from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from ChannelWidthWeighting import curveNumber, rainfallData
-
+from ChannelWidthWeighting import curveNumber, rainfallData, rainfallDistributionCurve
 
 app = FastAPI(
     title='SC Runoff Modeling Services',
@@ -58,6 +57,20 @@ class RainfallData(BaseModel):
             }
         }
 
+class RainfallDistributionCurve(BaseModel):
+
+    # all fields are required
+    lat: float
+    lon: float
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "lat": 33.3946,
+                "lon": -80.3474
+            }
+        }
+
 ######
 ##
 ## API Endpoints
@@ -69,7 +82,6 @@ class RainfallData(BaseModel):
 @app.get("/", include_in_schema=False)
 def docs_redirect_root():
     return RedirectResponse(url=app.docs_url)
-
 
 @app.post("/curvenumber/")
 def curvenumber(request_body: CurveNumber, response: Response):
@@ -127,6 +139,21 @@ def rainfalldata(request_body: RainfallData, response: Response):
             "P2_24_25": P2_24_25,
             "P2_24_50": P2_24_50,
             "P2_24_100": P2_24_100
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code = 500, detail =  str(e))
+
+@app.post("/rainfalldistributioncurve/")
+def rainfalldistributioncurve(request_body: RainfallDistributionCurve, response: Response):
+
+    try: 
+        response = rainfallDistributionCurve(
+            request_body.lat,
+            request_body.lon
+        )
+        return {
+            "response": response,
         }
 
     except Exception as e:


### PR DESCRIPTION
Closes #6 

The new `rainfalldistributioncurve` endpoint allows you to enter a coordinate and returns the NOAA rainfall distribution curve letter and number for that location. This automates this part of the [Spreadsheet for the SC Synthetic UH Method](https://doimspp.sharepoint.com/:x:/r/sites/SSPhaseII/Shared%20Documents/General/Planning/SC%20UH%20Method/SCDOT%20Spreadsheet_SC%20Synthetic%20UH%20Method_10%20June%202020.xlsm?d=w7adcdcb668f44f4e84347880f80b7844&csf=1&web=1&e=7pNbgk) (Rainfall Data sheet):
![image](https://user-images.githubusercontent.com/40237491/161786891-25063b55-32fc-4731-99b2-2a5a1d3aec03.png)

Type II and Type III curves will be handled in #9.

