### PR TITLE
Fixes #15 - Implement Bohman 1989 Method

### DIFF
--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -34,7 +34,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     regionLowerCoastalPlain1VR = 0.002652 * (A ** -0.953) * (Qp ** 0.978) * (regionLowerCoastalPlain1LT ** 0.882)
     regionLowerCoastalPlain2VR = 0.002872  * (A ** -0.953) * (Qp ** 0.978) * (regionLowerCoastalPlain2LT ** 0.882)
 
-    # Weight the regional Runoff Volume (VR) values
+    # Weighted average Runoff Volume for a rural basin (inches)
     weightedVR = (regionBlueRidgeFractionArea * regionBlueRidgeVR) + \
                  (regionPiedmontFractionArea * regionPiedmontVR) + \
                  (regionUpperCoastalPlainFractionArea * regionUpperCoastalPlainVR) + \
@@ -48,7 +48,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     regionLowerCoastalPlain1LTA = 6.95 * (A ** 0.348) * (Qp ** -0.022)
     regionLowerCoastalPlain2LTA = 11.7 * (A ** 0.348) * (Qp ** -0.022)
 
-    # Weight the Adjusted Lag Time (LTA) values
+    # Weighted Adjusted Lag Time (LTA) 
     weightedLTA = (regionBlueRidgeFractionArea * regionBlueRidgeLTA) + \
                  (regionPiedmontFractionArea * regionPiedmontLTA) + \
                  (regionUpperCoastalPlainFractionArea * regionUpperCoastalPlainLTA) + \
@@ -70,7 +70,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
                                             0.14, 0.13, 0.12, 0.12, 0.11,
                                             0.10, 0.10, 0.09 ]
     regionBlueRidgeDischargeRatio = np.asarray(regionBlueRidgeDischargeRatioList)
-    regionPiedmontDischargeRatioList =     [ 0.07, 0.09, 0.11, 0.14, 0.17,
+    regionPiedmontDischargeRatioList =    [ 0.07, 0.09, 0.11, 0.14, 0.17,
                                             0.21, 0.25, 0.30, 0.37, 0.44,
                                             0.53, 0.61, 0.70, 0.78, 0.86,
                                             0.92, 0.96, 0.99, 1.00, 0.98,
@@ -78,7 +78,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
                                             0.69, 0.63, 0.58, 0.53, 0.49,
                                             0.44, 0.41, 0.37, 0.34, 0.32,
                                             0.29, 0.27, 0.25, 0.23, 0.21,
-                                            0.19, 0.1, 0.16, 0.15, 0.13,
+                                            0.19, 0.18, 0.16, 0.15, 0.13,
                                             0.12, 0.11, 0.10 ]
     regionPiedmontDischargeRatio = np.asarray(regionPiedmontDischargeRatioList)
     regionCoastalPlainDischargeList =     [ 0.07, 0.10, 0.14, 0.18, 0.23,
@@ -108,27 +108,59 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     dischargeCoordinates = dischargeRatio * Qp
 
     # Show the scatter plot of the rural flood hydrograph (for testing)
-    #plt.scatter(timeCoordinates, dischargeCoordinates)
-    #plt.show()
+    # plt.scatter(timeCoordinates, dischargeCoordinates)
+    # plt.show()
 
-    # Check limitations of method from Table 15
+    ## Check limitations from Table 15
     warningMessage = "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
-    isWarning = False
+
+    # Check limitations for average basin lagtime
+    warningMessageLT = "One or more of the parameters is outside the suggested range; basin lagtime was estimated with unknown errors."
     if regionBlueRidgePercentArea > 0:
         if A < 2.83 or A > 455:
-            isWarning = True
+            warningMessage += warningMessageLT
     if regionPiedmontPercentArea > 0:
         if A < 0.52 or A > 444:
-            isWarning = True
+            warningMessage += warningMessageLT
     if regionUpperCoastalPlainPercentArea > 0:
         if A < 2.92 or A > 401:
-            isWarning = True
+            warningMessage += warningMessageLT
     if regionLowerCoastalPlain1PercentArea > 0 or regionLowerCoastalPlain2PercentArea > 0:
         if A < 7.67 or A > 401:
-            isWarning = True
+            warningMessage += warningMessageLT
 
-    if isWarning:
-        warningMessage = "One or more of the parameters may be outside the suggested range. Estimates were extrapolated with unknown errors. " + warningMessage
+    # Check limitations for runoff volume
+    warningMessageVR = "One or more of the parameters is outside the suggested range; runoff volume was estimated with unknown errors."
+    if regionBlueRidgePercentArea > 0:
+        if A < 30.2 or A > 455:
+            warningMessage += warningMessageVR
+        if Qp < 231 or Qp > 12800:
+            warningMessage += warningMessageVR
+        if regionBlueRidgeLT < 8.77 or regionBlueRidgeLT > 19.6:
+            warningMessage += warningMessageVR
+    if regionPiedmontPercentArea > 0:
+        if A < 0.52 or A > 444:
+            warningMessage += warningMessageVR
+        if Qp < 2.94 or Qp > 16400:
+            warningMessage += warningMessageVR
+        if regionPiedmontLT < 1.92 or regionPiedmontLT > 50.2:
+            warningMessage += warningMessageVR
+    if regionUpperCoastalPlainPercentArea > 0:
+        if A < 2.92 or A > 122:
+            warningMessage += warningMessageVR
+        if Qp < 10.4 or Qp > 625:
+            warningMessage += warningMessageVR
+        if regionUpperCoastalPlainLT < 9.88 or regionUpperCoastalPlainLT > 49.7:
+            warningMessage += warningMessageVR
+    if regionLowerCoastalPlain1PercentArea > 0 or regionLowerCoastalPlain2PercentArea > 0:
+        if A < 7.67 or A > 401:
+            warningMessage += warningMessageVR
+        if Qp < 16.7 or Qp > 2560:
+            warningMessage += warningMessageVR
+        if regionLowerCoastalPlain1LT < 11.7 or regionLowerCoastalPlain1LT > 95.5 or regionLowerCoastalPlain2LT < 11.7 or regionLowerCoastalPlain2LT > 95.5:
+            warningMessage += warningMessageVR
 
-    ## Note: if Runoff Volume is added to the variables returned, check limitations related to runoff volume in Table 15
-    return timeCoordinates.tolist(), dischargeCoordinates.tolist(), warningMessage
+    warningMessage += "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
+
+
+    return weightedVR, timeCoordinates.tolist(), dischargeCoordinates.tolist(), warningMessage

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -13,7 +13,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     # Qp: area-weighted flow statistic for the AEP of interest (cubic feet per second, float)
     # A: total basin drainage area (square miles, float)
 
-    # Check that some area is precent
+    # Check that some area is present
     if regionBlueRidgePercentArea + \
         regionPiedmontPercentArea + \
         regionUpperCoastalPlainPercentArea + \

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -5,13 +5,13 @@ import numpy as np
 # Report: https://doi.org/10.3133/wri894087
 def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPiedmontPercentArea, regionUpperCoastalPlainPercentArea,
                                             regionLowerCoastalPlain1PercentArea, regionLowerCoastalPlain2PercentArea, Qp, A):
-    # regionBlueRidgePercentArea: percent area of the basin that is in Blue Ridge (float)
-    # regionPiedmontPercentArea: percent area of the basin that is in Piedmont (float)
-    # regionUpperCoastalPlainPercentArea: percent area of the basin that is in Upper Coastal Plain (float)
-    # regionLowerCoastalPlain1PercentArea: percent area of the basin that is in Lower Coastal Plain Region 1 (float)
-    # regionLowerCoastalPlain2PercentArea: percent area of the basin that is in Lower Coastal Plain Region 2 (float)
-    # Qp: area-weighted flow statistic for the AEP of interest 
-    # A: total basin drainage area (square miles)
+    # regionBlueRidgePercentArea: percent area of the basin that is in Blue Ridge (percent, float)
+    # regionPiedmontPercentArea: percent area of the basin that is in Piedmont (percent, float)
+    # regionUpperCoastalPlainPercentArea: percent area of the basin that is in Upper Coastal Plain (percent, float)
+    # regionLowerCoastalPlain1PercentArea: percent area of the basin that is in Lower Coastal Plain Region 1 (percent, float)
+    # regionLowerCoastalPlain2PercentArea: percent area of the basin that is in Lower Coastal Plain Region 2 (percent, float)
+    # Qp: area-weighted flow statistic for the AEP of interest (cubic feet per second, float)
+    # A: total basin drainage area (square miles, float)
 
     # Calculate the fraction area of each region
     regionBlueRidgeFractionArea = regionBlueRidgePercentArea / 100.0

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -13,6 +13,14 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     # Qp: area-weighted flow statistic for the AEP of interest (cubic feet per second, float)
     # A: total basin drainage area (square miles, float)
 
+    # Check that some area is precent
+    if regionBlueRidgePercentArea + \
+        regionPiedmontPercentArea + \
+        regionUpperCoastalPlainPercentArea + \
+        regionLowerCoastalPlain1PercentArea + \
+        regionLowerCoastalPlain2PercentArea == 0:
+        raise Exception("No area present for relevant Regression Regions.")
+
     # Calculate the fraction area of each region
     regionBlueRidgeFractionArea = regionBlueRidgePercentArea / 100.0
     regionPiedmontFractionArea = regionPiedmontPercentArea / 100.0
@@ -112,7 +120,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
     # plt.show()
 
     ## Check limitations from Table 15
-    warningMessage = "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
+    warningMessage = ""
 
     # Check limitations for average basin lagtime
     warningMessageLT = "One or more of the parameters is outside the suggested range; basin lagtime was estimated with unknown errors."
@@ -161,6 +169,5 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
             warningMessage += warningMessageVR
 
     warningMessage += "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
-
 
     return weightedVR, timeCoordinates.tolist(), dischargeCoordinates.tolist(), warningMessage

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -1,3 +1,134 @@
-def computeRuralFloodHydrographBohman1989(lat, lon, region3PercentArea, region4PercentArea, region3AEP, region4AEP, A, L, S, TIA):
+import numpy as np
+# import matplotlib.pyplot as plt
 
-    return 
+# Compute flood hydrographs for rural watersheds based on the Bohman 1989 method
+# Report: https://doi.org/10.3133/wri894087
+def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPiedmontPercentArea, regionUpperCoastalPlainPercentArea,
+                                            regionLowerCoastalPlain1PercentArea, regionLowerCoastalPlain2PercentArea, Qp, A):
+    # regionBlueRidgePercentArea: percent area of the basin that is in Blue Ridge (float)
+    # regionPiedmontPercentArea: percent area of the basin that is in Piedmont (float)
+    # regionUpperCoastalPlainPercentArea: percent area of the basin that is in Upper Coastal Plain (float)
+    # regionLowerCoastalPlain1PercentArea: percent area of the basin that is in Lower Coastal Plain Region 1 (float)
+    # regionLowerCoastalPlain2PercentArea: percent area of the basin that is in Lower Coastal Plain Region 2 (float)
+    # Qp: area-weighted flow statistic for the AEP of interest 
+    # A: total basin drainage area (square miles)
+
+    # Calculate the fraction area of each region
+    regionBlueRidgeFractionArea = regionBlueRidgePercentArea / 100.0
+    regionPiedmontFractionArea = regionPiedmontPercentArea / 100.0
+    regionUpperCoastalPlainFractionArea = regionUpperCoastalPlainPercentArea / 100.0
+    regionLowerCoastalPlain1FractionArea = regionLowerCoastalPlain1PercentArea / 100.0
+    regionLowerCoastalPlain2FractionArea = regionLowerCoastalPlain2PercentArea / 100.0
+
+    # Calculate Lag Time (LT) based on Table 11 equations
+    regionBlueRidgeLT = 3.71 * (A ** 0.265)
+    regionPiedmontLT =  2.66 * (A ** 0.460)
+    regionUpperCoastalPlainLT = 6.10 * (A ** 0.417)
+    regionLowerCoastalPlain1LT = 6.62 * (A ** 0.341)
+    regionLowerCoastalPlain2LT = 10.88 * (A ** 0.341)
+
+    # Calculate Runoff Volume (VR) based on Table 13 equations
+    regionBlueRidgeVR = 0.003780 * (A ** -0.911) * (Qp ** 0.888) * (regionBlueRidgeLT ** 0.879)
+    regionPiedmontVR = 0.002418 * (A ** -0.798) * (Qp ** 0.880) * (regionPiedmontLT ** 0.896)
+    regionUpperCoastalPlainVR = 0.003854 * (A ** -0.926) * (Qp ** 0.990) * (regionUpperCoastalPlainLT ** 0.721)
+    regionLowerCoastalPlain1VR = 0.002652 * (A ** -0.953) * (Qp ** 0.978) * (regionLowerCoastalPlain1LT ** 0.882)
+    regionLowerCoastalPlain2VR = 0.002872  * (A ** -0.953) * (Qp ** 0.978) * (regionLowerCoastalPlain2LT ** 0.882)
+
+    # Weight the regional Runoff Volume (VR) values
+    weightedVR = (regionBlueRidgeFractionArea * regionBlueRidgeVR) + \
+                 (regionPiedmontFractionArea * regionPiedmontVR) + \
+                 (regionUpperCoastalPlainFractionArea * regionUpperCoastalPlainVR) + \
+                 (regionLowerCoastalPlain1FractionArea * regionLowerCoastalPlain1VR) + \
+                 (regionLowerCoastalPlain2FractionArea * regionLowerCoastalPlain2VR) 
+    
+    # Calculate the Adjusted Lag Time (LTA) based on Equations 8 through 12
+    regionBlueRidgeLTA = 7.21 * (A ** 0.322) * (Qp ** -0.112)
+    regionPiedmontLTA = 3.30 * (A ** 0.614) * (Qp ** -0.120)
+    regionUpperCoastalPlainLTA = 7.03 * (A ** 0.375) * (Qp ** -0.010)
+    regionLowerCoastalPlain1LTA = 6.95 * (A ** 0.348) * (Qp ** -0.022)
+    regionLowerCoastalPlain2LTA = 11.7 * (A ** 0.348) * (Qp ** -0.022)
+
+    # Weight the Adjusted Lag Time (LTA) values
+    weightedLTA = (regionBlueRidgeFractionArea * regionBlueRidgeLTA) + \
+                 (regionPiedmontFractionArea * regionPiedmontLTA) + \
+                 (regionUpperCoastalPlainFractionArea * regionUpperCoastalPlainLTA) + \
+                 (regionLowerCoastalPlain1FractionArea * regionLowerCoastalPlain1LTA) + \
+                 (regionLowerCoastalPlain2FractionArea * regionLowerCoastalPlain2LTA) 
+
+    ## Table 3: Time and discharge ratios of the dimensionless hydrographs for the indicated regions
+    # Time ratio: t / LTA
+    timeRatio = np.arange(0.15,2.55,0.05)
+    # Discharge ratio: Q / Qp
+    regionBlueRidgeDischargeRatioList =   [ 0.08, 0.14, 0.22, 0.31, 0.43,
+                                            0.56, 0.69, 0.80, 0.89, 0.96,
+                                            0.99, 1.00, 0.97, 0.93, 0.88,
+                                            0.82, 0.76, 0.71, 0.65, 0.60,
+                                            0.56, 0.51, 0.47, 0.44, 0.41,
+                                            0.38, 0.35, 0.33, 0.30, 0.28,
+                                            0.26, 0.24, 0.23, 0.21, 0.20,
+                                            0.19, 0.17, 0.16, 0.15, 0.14,
+                                            0.14, 0.13, 0.12, 0.12, 0.11,
+                                            0.10, 0.10, 0.09 ]
+    regionBlueRidgeDischargeRatio = np.asarray(regionBlueRidgeDischargeRatioList)
+    regionPiedmontDischargeRatioList =     [ 0.07, 0.09, 0.11, 0.14, 0.17,
+                                            0.21, 0.25, 0.30, 0.37, 0.44,
+                                            0.53, 0.61, 0.70, 0.78, 0.86,
+                                            0.92, 0.96, 0.99, 1.00, 0.98,
+                                            0.96, 0.91, 0.86, 0.80, 0.74,
+                                            0.69, 0.63, 0.58, 0.53, 0.49,
+                                            0.44, 0.41, 0.37, 0.34, 0.32,
+                                            0.29, 0.27, 0.25, 0.23, 0.21,
+                                            0.19, 0.1, 0.16, 0.15, 0.13,
+                                            0.12, 0.11, 0.10 ]
+    regionPiedmontDischargeRatio = np.asarray(regionPiedmontDischargeRatioList)
+    regionCoastalPlainDischargeList =     [ 0.07, 0.10, 0.14, 0.18, 0.23,
+                                            0.29, 0.35, 0.42, 0.50, 0.57,
+                                            0.64, 0.71, 0.78, 0.85, 0.90,
+                                            0.94, 0.97, 0.99, 1.00, 0.99,
+                                            0.98, 0.95, 0.92, 0.88, 0.84,
+                                            0.80, 0.76, 0.72, 0.68, 0.63,
+                                            0.59, 0.55, 0.51, 0.48, 0.44,
+                                            0.40, 0.37, 0.34, 0.31, 0.28,
+                                            0.25, 0.23, 0.20, 0.18, 0.17,
+                                            0.15, 0.13, 0.11 ]
+    regionCoastalPlainDischargeRatio = np.asarray(regionCoastalPlainDischargeList)
+
+    # Determine the region with the largest percentage of drainage
+    percentAreas = [regionBlueRidgePercentArea, regionPiedmontPercentArea, regionUpperCoastalPlainPercentArea + regionLowerCoastalPlain1PercentArea + regionLowerCoastalPlain2PercentArea]
+    max_percentArea_index = percentAreas.index(max(percentAreas))
+    if max_percentArea_index == 0:
+        dischargeRatio = regionBlueRidgeDischargeRatio
+    elif max_percentArea_index == 1:
+        dischargeRatio = regionPiedmontDischargeRatio
+    else: 
+        dischargeRatio = regionCoastalPlainDischargeRatio
+
+    # Calculate coordinates for the rural flood hydrograph
+    timeCoordinates = timeRatio * weightedLTA
+    dischargeCoordinates = dischargeRatio * Qp
+
+    # Show the scatter plot of the rural flood hydrograph (for testing)
+    #plt.scatter(timeCoordinates, dischargeCoordinates)
+    #plt.show()
+
+    # Check limitations of method from Table 15
+    warningMessage = "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
+    isWarning = False
+    if regionBlueRidgePercentArea > 0:
+        if A < 2.83 or A > 455:
+            isWarning = True
+    if regionPiedmontPercentArea > 0:
+        if A < 0.52 or A > 444:
+            isWarning = True
+    if regionUpperCoastalPlainPercentArea > 0:
+        if A < 2.92 or A > 401:
+            isWarning = True
+    if regionLowerCoastalPlain1PercentArea > 0 or regionLowerCoastalPlain2PercentArea > 0:
+        if A < 7.67 or A > 401:
+            isWarning = True
+
+    if isWarning:
+        warningMessage = "One or more of the parameters may be outside the suggested range. Estimates were extrapolated with unknown errors. " + warningMessage
+
+    ## Note: if Runoff Volume is added to the variables returned, check limitations related to runoff volume in Table 15
+    return timeCoordinates.tolist(), dischargeCoordinates.tolist(), warningMessage

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -1,0 +1,3 @@
+def computeRuralFloodHydrographBohman1989(lat, lon, region3PercentArea, region4PercentArea, region3AEP, region4AEP, A, L, S, TIA):
+
+    return 

--- a/Bohman_Method_1989.py
+++ b/Bohman_Method_1989.py
@@ -138,7 +138,7 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
             warningMessage += warningMessageLT
 
     # Check limitations for runoff volume
-    warningMessageVR = "One or more of the parameters is outside the suggested range; runoff volume was estimated with unknown errors."
+    warningMessageVR = "One or more of the parameters is outside the suggested range; runoff volume was estimated with unknown errors. "
     if regionBlueRidgePercentArea > 0:
         if A < 30.2 or A > 455:
             warningMessage += warningMessageVR
@@ -168,6 +168,6 @@ def computeRuralFloodHydrographBohman1989(regionBlueRidgePercentArea, regionPied
         if regionLowerCoastalPlain1LT < 11.7 or regionLowerCoastalPlain1LT > 95.5 or regionLowerCoastalPlain2LT < 11.7 or regionLowerCoastalPlain2LT > 95.5:
             warningMessage += warningMessageVR
 
-    warningMessage += "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant."
+    warningMessage += "These methods are not applicable to streams where regulation, urbanization, temporary in-channel storage, or overbank detention storage is significant. "
 
     return weightedVR, timeCoordinates.tolist(), dischargeCoordinates.tolist(), warningMessage

--- a/main.py
+++ b/main.py
@@ -71,6 +71,30 @@ class RainfallDistributionCurve(BaseModel):
                 "lon": -80.3474
             }
         }
+class RuralHydrographBohman1989(BaseModel):
+
+    regionBlueRidgePercentArea: float = Field(0.0, title="Blue Ridge region percent area", description="percent area of the basin that is in the Blue Ridge region (percent, float)", example="0.0")
+    regionPiedmontPercentArea: float = Field(0.0, title="Piedmont region percent area", description="percent area of the basin that is in the Piedmont region (percent, float)", example="0.0")
+    regionUpperCoastalPlainPercentArea: float = Field(0.0, title="Upper Coastal Plain region percent area", description="percent area of the basin that is in the Upper Coastal Plain region (percent, float)", example="0.0")
+    regionLowerCoastalPlain1PercentArea: float = Field(0.0, title="Lower Coastal Plain region 1 percent area", description="percent area of the basin that is in the Lower Coastal Plain region 1 (percent, float)", example="0.0")
+    regionLowerCoastalPlain2PercentArea: float = Field(0.0, title="Lower Coastal Plain region 2 percent area", description="percent area of the basin that is in the Lower Coastal Plain region 2 (percent, float)", example="0.0")
+    Qp: float = Field(0.0, title="weighted Qp", description="flow statistic for the AEP of interest (ex. 'UPK50AEP') in Region_3_Urban_2014_5030 (cubic feet per second, float)", example="0.0")
+    region4Qp: float = Field(0.0, title="region 4 Qp", description="area-weighted flow statistic for the AEP of interest (cubic feet per second, float)", example="35.7")
+    A: float = Field(..., title="basin area", description="total drainage area of the delineated basin (square miles, float)", example="0.058")
+
+    class Config:
+        null = 0.0 # null values will become 0.0
+        schema_extra = {
+            "example": {
+                "regionBlueRidgePercentArea": 0.0,
+                "regionPiedmontPercentArea": 0.0,
+                "regionUpperCoastalPlainPercentArea": 0.0,
+                "regionLowerCoastalPlain1PercentArea": 0.0,
+                "regionLowerCoastalPlain2PercentArea": 0.0,
+                "Qp": 0.0,
+                "A": 0.058,
+            }
+        }
 
 ######
 ##

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from SC_Synthetic_UH_Method import curveNumber, rainfallData, rainfallDistributionCurve
 from Bohman_Method_1989 import computeRuralFloodHydrographBohman1989
@@ -74,25 +74,25 @@ class RainfallDistributionCurve(BaseModel):
         }
 class RuralHydrographBohman1989(BaseModel):
 
-    regionBlueRidgePercentArea: float = Field(0.0, title="Blue Ridge region percent area", description="percent area of the basin that is in the Blue Ridge region (percent, float)", example="0.0")
-    regionPiedmontPercentArea: float = Field(0.0, title="Piedmont region percent area", description="percent area of the basin that is in the Piedmont region (percent, float)", example="0.0")
+    regionBlueRidgePercentArea: float = Field(0.0, title="Blue Ridge region percent area", description="percent area of the basin that is in the Blue Ridge region (percent, float)", example="10.0")
+    regionPiedmontPercentArea: float = Field(0.0, title="Piedmont region percent area", description="percent area of the basin that is in the Piedmont region (percent, float)", example="90.0")
     regionUpperCoastalPlainPercentArea: float = Field(0.0, title="Upper Coastal Plain region percent area", description="percent area of the basin that is in the Upper Coastal Plain region (percent, float)", example="0.0")
     regionLowerCoastalPlain1PercentArea: float = Field(0.0, title="Lower Coastal Plain region 1 percent area", description="percent area of the basin that is in the Lower Coastal Plain region 1 (percent, float)", example="0.0")
     regionLowerCoastalPlain2PercentArea: float = Field(0.0, title="Lower Coastal Plain region 2 percent area", description="percent area of the basin that is in the Lower Coastal Plain region 2 (percent, float)", example="0.0")
-    Qp: float = Field(0.0, title="weighted Qp", description="flow statistic for the AEP of interest (ex. 'UPK50AEP') in Region_3_Urban_2014_5030 (cubic feet per second, float)", example="0.0")
-    A: float = Field(..., title="basin area", description="total drainage area of the delineated basin (square miles, float)", example="0.058")
+    Qp: float = Field(..., title="weighted Qp", description="area-weighted flow statistic for the AEP of interest (cubic feet per second, float)", example="400.0")
+    A: float = Field(..., title="basin area", description="total drainage area of the delineated basin (square miles, float)", example="35.0")
 
     class Config:
         null = 0.0 # null values will become 0.0
         schema_extra = {
             "example": {
-                "regionBlueRidgePercentArea": 0.0,
-                "regionPiedmontPercentArea": 0.0,
+                "regionBlueRidgePercentArea": 10.0,
+                "regionPiedmontPercentArea": 90.0,
                 "regionUpperCoastalPlainPercentArea": 0.0,
                 "regionLowerCoastalPlain1PercentArea": 0.0,
                 "regionLowerCoastalPlain2PercentArea": 0.0,
-                "Qp": 0.0,
-                "A": 0.058,
+                "Qp": 400.0,
+                "A": 35.0,
             }
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ idna==3.3
 isort==5.6.4
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
+numpy==1.22.3
 platformdirs==2.0.2
 pydantic==1.9.0
 pylint==2.6.0


### PR DESCRIPTION
Closes #15

Based on this file: [Steps for computing a simulated rural hydrograph from methods in WRIR 89.docx](https://github.com/USGS-WiM/SC-RunoffModelingServices/files/8453811/Steps.for.computing.a.simulated.rural.hydrograph.from.methods.in.WRIR.89.docx)

Relevant report: [Bohman 1989](https://pubs.usgs.gov/wri/1989/4087/report.pdf)

The Bohman 1989 report demonstrates a way to develop flood hydrographs in South Carolina for rural watersheds in several regression regions: Blue Ridge, Piedmont, Upper Coastal Plain, Lower Coastal Plain Region 1, and Lower Coastal Plain Region 2. We are awaiting information from Kitty about how these regions correspond to current StreamStats Regression Regions, and some new Regression Regions may need to be added.

A new `ruralhydrographbohman1989` endpoint is added. This endpoint takes the following inputs: 

- regionBlueRidgePercentArea: percent area of the basin that is in Blue Ridge
- regionPiedmontPercentArea: ercent area of the basin that is in Piedmont 
- regionUpperCoastalPlainPercentArea: percent area of the basin that is in Upper Coastal Plain
- regionLowerCoastalPlain1PercentArea: percent area of the basin that is in Lower Coastal Plain Region 1
- regionLowerCoastalPlain2PercentArea: percent area of the basin that is in Lower Coastal Plain Region 2
- A: drainage area of the basin
- Qp: area-weighted flow statistic for the AEP of interest 

The endpoint returns the following outputs:

- weightedVR: weighted average runoff volume for a rural basin
- timeCoordinates: x values for the urban flood hydrograph
- dischargeCoordinates: y values for the urban flood hydrograph
- warningMessage: provides warning information in the response headers about method limitations

These x and y values can be used to be produce a figure in the client.

If no values or null values are provided any region's PercentArea input, it will default to zero.
