### PR TITLE
Update deployment instructions - fix service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once the above code has been run successfully, the service documentation will be
      - Click "Open" to connect
  3. Go to the app directory: `cd /var/www/SC-RunoffModelingServices`
  4. Pull the latest code: `sudo git pull origin master`
- 5. Restart the daemon: `sudo systemctl restart sc-runoffmodeling`
+ 5. Restart the daemon: `sudo systemctl restart SC-RunoffModelingServices`
  6. Check that the services were updated: https://sc-runoffmodelingservices.streamstats.usgs.gov/docs
  7. Exit when finished: `exit`
 


### PR DESCRIPTION
Fix name of service name on the FastAPI server in the deployment documentation