### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added 
 
-- lagtimetc endpoint: computes Time of Concentration by the Lag Time Equation Method
-- traveltimetc endpoint: computes Time of Concentration by the Travel Time Method
-- weightedcurvenumber endpoint: calculates area-weighted or runoff-weighted curve number data (currently contains placeholder raw curve number data)
-- PRF endpoint: returns Peak Rate Factor data (currently returns placeholder PRF data)
-- scsyntheticunithydrograph endpoint: computes SC Synthetic Unit Hydrograph data
-- calculateMissingParametersSCSUH endpoint: combines rainfallDistributionCurve, PRFData, weightedCurveNumber, and travelTimeMethodTimeOfConcentration or lagTimeMethodTimeOfConcentration (depending on TcMethod) into single function
+-  
 
 ### Changed  
 
@@ -35,7 +30,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security  
 
 
+- 
 
+## [v0.2.0](https://github.com/USGS-WiM/SC-RunoffModelingServices/releases/tag/v0.2.0) - 2022-07-29
+### Added
+
+- lagtimetc endpoint: computes Time of Concentration by the Lag Time Equation Method
+- traveltimetc endpoint: computes Time of Concentration by the Travel Time Method
+- weightedcurvenumber endpoint: calculates area-weighted or runoff-weighted curve number data (currently contains placeholder raw curve number data)
+- PRF endpoint: returns Peak Rate Factor data (currently returns placeholder PRF data)
+- scsyntheticunithydrograph endpoint: computes SC Synthetic Unit Hydrograph data
+- calculateMissingParametersSCSUH endpoint: combines rainfallDistributionCurve, PRFData, weightedCurveNumber, and travelTimeMethodTimeOfConcentration or lagTimeMethodTimeOfConcentration (depending on TcMethod) into single function
+  
 ## [v0.1.1](https://github.com/USGS-WiM/SC-RunoffModelingServices/releases/tag/v0.1.1) - 2022-06-30
 ### Fixed  
 

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "SC-RunoffModelingServices",
     "organization": "U.S. Geological Survey",
     "description": "FastAPI Python services for South Carolina Runoff Modeling Services to support South Carolina StreamStats Phase II",
-    "version": "v0.1.1",
+    "version": "v0.2.0",
     "status": "Development",
 
     "permissions": {


### PR DESCRIPTION
Part of #52

### Added 

- lagtimetc endpoint: computes Time of Concentration by the Lag Time Equation Method
- traveltimetc endpoint: computes Time of Concentration by the Travel Time Method
- weightedcurvenumber endpoint: calculates area-weighted or runoff-weighted curve number data (currently contains placeholder raw curve number data)
- PRF endpoint: returns Peak Rate Factor data (currently returns placeholder PRF data)
- scsyntheticunithydrograph endpoint: computes SC Synthetic Unit Hydrograph data
- calculateMissingParametersSCSUH endpoint: combines rainfallDistributionCurve, PRFData, weightedCurveNumber, and travelTimeMethodTimeOfConcentration or lagTimeMethodTimeOfConcentration (depending on TcMethod) into single function
