### PR TITLE
release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  
 
-### Changed  
+# Changed
 
-- Service URL changed from https://sc-runoffmodelingservices.streamstats.usgs.gov/ to https://streamstats.usgs.gov/local/scrunoffservices
-- Changed PRF endpoint to take a list of PRF and Area inputs to calculate PRF value
+- 
 
 ### Deprecated 
 
@@ -22,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed 
 
-- Removed warning messages from travelTimeMethodTimeOfConcentration
+- 
 
 ### Fixed  
 
@@ -31,7 +30,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security  
 
 
+## [v0.3.0](https://github.com/USGS-WiM/SC-RunoffModelingServices/releases/tag/v0.3.1) - 2022-10-11
 
+### Changed  
+
+- Service URL changed from https://sc-runoffmodelingservices.streamstats.usgs.gov/ to https://streamstats.usgs.gov/local/scrunoffservices
+- Changed PRF endpoint to take a list of PRF and Area inputs to calculate PRF value
+
+### Removed 
+
+- Removed warning messages from travelTimeMethodTimeOfConcentration
 
 ## [v0.2.1](https://github.com/USGS-WiM/SC-RunoffModelingServices/releases/tag/v0.2.1) - 2022-08-08
 

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "SC-RunoffModelingServices",
     "organization": "U.S. Geological Survey",
     "description": "FastAPI Python services for South Carolina Runoff Modeling Services to support South Carolina StreamStats Phase II",
-    "version": "v0.2.1",
+    "version": "v0.3.0",
     "status": "Development",
 
     "permissions": {


### PR DESCRIPTION
### Changed  

- Service URL changed from https://sc-runoffmodelingservices.streamstats.usgs.gov/ to https://streamstats.usgs.gov/local/scrunoffservices
- Changed PRF endpoint to take a list of PRF and Area inputs to calculate PRF value

### Removed 

- Removed warning messages from travelTimeMethodTimeOfConcentration