### PR TITLE
Fixes #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed  
 
 - Options in main.py so application runs on server properly
+- Bug that caused return of incorrect number of flow values for SC Synthetic Unit Hydrograph
 
 ### Security  
 

--- a/SC_Synthetic_UH_Method.py
+++ b/SC_Synthetic_UH_Method.py
@@ -425,7 +425,7 @@ def computeSCSyntheticUnitHydrograph(lat, lon, AEP, CNModificationMethod, Area, 
 
         # Compute unit hydrograph from the "Q[100/AEP]_[D]" sheets
         burst_increments = Inc_QCN_values
-        times = np.arange(0,2*24*60,burst_duration).tolist()
+        times = np.arange(0,(2*24*60)+burst_duration,burst_duration).tolist()
         UH = []
         for time in times:
             UH.append(UH_Qp*((time/UH_Tp)*math.exp(1.0-time/UH_Tp))**(Gamma_n-1.0))


### PR DESCRIPTION
Fixed off by one bug by using the same line of code for `times` that is used by `"time"`, https://github.com/USGS-WiM/SC-RunoffModelingServices/blob/dev/SC_Synthetic_UH_Method.py#L494.


I revert PR #72 to test the change. 