### PR TITLE
Fixes #84 - service link updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Options in main.py so application runs on server properly
 - Bug that caused return of incorrect number of flow values for SC Synthetic Unit Hydrograph
 - Instructions in README.md to run locally
-- NOAA Precipitation Frequency Data Server link
 
 ### Security  
 

--- a/SC_Synthetic_UH_Method.py
+++ b/SC_Synthetic_UH_Method.py
@@ -244,7 +244,7 @@ def gammaN(PRF):
 def rainfallData(lat, lon):
 
     # Request data from NOAA
-    requestURL = "https://hdsc.nws.noaa.gov/cgi-bin/new/cgi_readH5.py?lat={}&lon={}".format(lat, lon)
+    requestURL = "https://hdsc.nws.noaa.gov/cgi-bin/hdsc/new/cgi_readH5.py?lat={}&lon={}".format(lat, lon)
     response = requests.get(requestURL)
     if response.status_code == 200:
         response_content = response.content.decode('utf-8')


### PR DESCRIPTION
URL changed back to from
https://hdsc.nws.noaa.gov/cgi-bin/hdsc/new/cgi_readH5.py?lat=33.8000&lon=-81.0000
to
https://hdsc.nws.noaa.gov/cgi-bin/new/cgi_readH5.py?lat=33.8000&lon=-81.0000