### PR TITLE
Fixes #55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -  Exception if user enters a value for Overland Slope that is less than or equal to 0
 -  AEP options 20%, 50%, and 100%  to SC Synthetic Unit Hydrograph method
+-  Added stormponds endpoint
 
 # Changed
 

--- a/SC_Synthetic_UH_Method.py
+++ b/SC_Synthetic_UH_Method.py
@@ -309,7 +309,6 @@ def rainfallData(lat, lon):
     data_string = response_content[response_content.index("quantiles = ")+len("quantiles = "):response_content.index("upper")-2] # String of data
     data_lists = ast.literal_eval(data_string) # Convert string to list of lists
     results = [list(map(float, sublist)) for sublist in data_lists] # Convert string values to floating point
-    print(results[4])
 
     # Precipitation frequency estimates (inches) by duration of storms (hours): 1, 2, 3, 6, 12, 24
     # Columns correspond to average recurrence interval (years): 1, 2, 5, 10, 25, 50, 100, 200, 500, 1000

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -21,16 +21,16 @@ def calcponds():
     # TODO: These all need to be upper inputs
     unitHydrograph = computeSCSyntheticUnitHydrograph(33.3946, -80.3474, 10, "Merkel", 100.0, 78, "II", 240, 66.9, 4.94, 0.99)
 
-    #pond 1
+    # pond 1
     length = 200
     w1 = 200
     w2 = 200
     side_slope_z = 3
     bottom_slope = .5
 
-    #pond 2
+    # pond 2
 
-    #both
+    # both
     pond_bottom_elev = 100
     Orif1_Coeff=.6
     Orif1_Dia = 6
@@ -61,7 +61,7 @@ def calcponds():
     A = [] # Y-S (1)
     change_S = [] # Pond_1 hr
     twoS_dtplusQ = [] # Y-S (1)
-    Y = []
+    Y = [] # Pond_X hr, 2S_Dt, Y-Q (1)
     # Caluclate values in Y-Q (1) sheet
     Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
     Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
@@ -117,112 +117,133 @@ def calcponds():
 
         
 
-    print(Q) 
-    print(S)
-    print(twoS_dtplusQ)
-    print('Y:', Y)
+    # print('Q:', Q) 
+    # print('S:', S)
+    # print('twoS_dtplusQ:', twoS_dtplusQ)
+    # print('Y:', Y)
 
-    # TODO Loop thorugh storm_duration
-    # Initlaize arrays used in 
-    time = unitHydrograph[3]['time'] # pond_x hr
-    inflow = unitHydrograph[3]['flow_1_hour'] # pond_x hr TODO depends on storm_duration loop
-    i1plusi2 = [] # pond_x hr (column E)
-    twoS_dtplusQ2 = [] # pond_x hr (column F)
-    twoS_dtminusQ1 = [] # pond_x hr (column E)
-    Q2 = [] # pond_x hr (column H)
-    Y2 = [] # pond_x hr (column G)
-    outflows = [] # pond_x hr (as Q2) & D-hr Storm Pond Routing Results
-    counter = 0
-
-
-
-    for t in time:
-        if counter == 0:
-            i1plusi2.append(0)
-            twoS_dtminusQ1.append(0)
-            twoS_dtplusQ2.append(0)
-            Y2.append(0)
-            Q2.append(0)
-        else:
-            i1plusi2.append(inflow[counter-1] + inflow[counter])
-            twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
-            twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
-            # Q2 & Y2
-            if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
-                Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[0]))
-                Y2.append(Y[0]+((Y[1]-Y[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[0]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
-                Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[1]))
-                Y2.append(Y[1]+((Y[2]-Y[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[1]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
-                Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[2]))
-                Y2.append(Y[2]+((Y[3]-Y[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[2]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]):                 
-                Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[3]))
-                Y2.append(Y[3]+((Y[4]-Y[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[3]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
-                Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[4]))
-                Y2.append(Y[4]+((Y[5]-Y[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[4]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
-                Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[5]))
-                Y2.append(Y[5]+((Y[6]-Y[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[5]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
-                Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[6]))
-                Y2.append(Y[6]+((Y[7]-Y[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[6]))
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
-                Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[7])) 
-                Y2.append(Y[7]+((Y[8]-Y[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[7])) 
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
-                Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8]))
-                Y2.append(Y[8]+((Y[9]-Y[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8]))  
-            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
-                Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[9])) 
-                Y2.append(Y[9]+((Y[10]-Y[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[9])) 
+    outflows = []
+    # Loop thorugh storm_duration
+    for D in storm_duration:
+        # Initlaize arrays used in 
+        time = unitHydrograph[3]['time'] # pond_x hr(column B)
+        inflow = unitHydrograph[3]['flow_' + str(D) + '_hour'] # pond_x hr (column C)
+        i1plusi2 = [] # pond_x hr (column D)
+        twoS_dtplusQ2 = [] # pond_x hr (column F)
+        twoS_dtminusQ1 = [] # pond_x hr (column E)
+        Q2 = [] # pond_x hr (column H) & D-hr Storm Pond Routing Results
+        Y2 = [] # pond_x hr (column G)
+        counter = 0
+    
+        for t in time:
+            if counter == 0:
+                i1plusi2.append(0)
+                twoS_dtminusQ1.append(0)
+                twoS_dtplusQ2.append(0)
+                Y2.append(0)
+                Q2.append(0)
             else:
-                Q2.append('error') 
-                Y2.append('error')
-        counter = counter + 1
+                i1plusi2.append(inflow[counter-1] + inflow[counter])
+                twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
+                twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
+                # Q2 & Y2
+                if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
+                    print(1)
+                    Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
+                    Y2.append(Y[0]+((Y[1]-Y[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
+                    Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
+                    Y2.append(Y[1]+((Y[2]-Y[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
+                    print(3)
+                    Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
+                    Y2.append(Y[2]+((Y[3]-Y[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]): 
+                    print(4)                
+                    Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
+                    Y2.append(Y[3]+((Y[4]-Y[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
+                    print(5)
+                    Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
+                    Y2.append(Y[4]+((Y[5]-Y[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
+                    print(6)
+                    Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
+                    Y2.append(Y[5]+((Y[6]-Y[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
+                    print(7)
+                    Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
+                    Y2.append(Y[6]+((Y[7]-Y[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
+                    print(8)
+                    Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
+                    Y2.append(Y[7]+((Y[8]-Y[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
+                    print(9)
+                    Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))
+                    Y2.append(Y[8]+((Y[9]-Y[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))  
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
+                    print(10)
+                    Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
+                    Y2.append(Y[9]+((Y[10]-Y[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
+                else:
+                    Q2.append('error') 
+                    Y2.append('error')
+            counter = counter + 1
+        outflows.append(Q2)
+        
+        index_pond_peak_inflow = np.argmax(inflow)
+        pond_peak_inflow.append((inflow[index_pond_peak_inflow]))
+        time_of_pond_peak_inflow.append(time[index_pond_peak_inflow])
+        index_pond_peak_outflow = np.argmax(Q2)
+        pond_peak_outflow.append(Q2[index_pond_peak_outflow])
+        time_of_pond_peak_outflow.append(time[index_pond_peak_outflow])
+        pond_max_depth.append(max(Y2))
+        # print('time:', time)
+        # print('inflow:', inflow)
+        # print('i1plusi2:', i1plusi2)
+        # print('twoS_dtminusQ1:', twoS_dtminusQ1)
+        # print('twoS_dtplusQ2:', twoS_dtplusQ2)
+        # print('Q2:', Q2)
+        # print('Y2:', Y2)
+    
 
-    print('time:', time)
-    print('inflow:', inflow)
-    print('i1plusi2:', i1plusi2)
-    print('twoS_dtminusQ1:', twoS_dtminusQ1)
-    print('twoS_dtplusQ2:', twoS_dtplusQ2)
-    print('Q2:', Q2)
-    print('Y2:', Y2)
+    
 
     # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
-    #index_max_peak_outflow = np.argmax(pond_peak_outflow)
-    #max_peak_outflow = storm_duration[index_max_peak_outflow]
-    max_peak_outflow = 6
+    index_max_peak_outflow = np.argmax(pond_peak_outflow)
+    max_peak_outflow = storm_duration[index_max_peak_outflow]
 
     runoff_and_ponding_results = {
-        # "storm_duration": unitHydrograph[2]['storm_duration'],
-        # "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
-        # "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  # I think the spreadsheet is wrong here 
-        # "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
-        # "pond_peak_inflow": pond_peak_inflow, # max of inflow (pond_x hr 19)
-        # "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow (pond_x hr k20)
-        # "pond_peak_outflow": pond_peak_outflow, # max of outflow (pond_x hr k22)
-        # "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow (pond_x hr k23)
-        # "max_peak_outflow_storm_duration": max_peak_outflow, # storm duration with max peak outflow
-        # "max_depth": pond_max_depth # max_depth (pond_x hr k24)
+        "storm_duration": unitHydrograph[2]['storm_duration'],
+        "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
+        "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  
+        "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
+        "pond_peak_inflow": pond_peak_inflow, # max of inflow (pond_x hr 19)
+        "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow (pond_x hr k20)
+        "pond_peak_outflow": pond_peak_outflow, # max of outflow (pond_x hr k22)
+        "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow (pond_x hr k23)
+        "max_peak_outflow_storm_duration": max_peak_outflow, # storm duration with max peak outflow
+        "max_depth": pond_max_depth # max_depth (pond_x hr k24)
     }
 
     pond_inflow_and_outflow_ordinates = {
-        # "time": unitHydrograph[3]['time'],
-        # "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
-        # "outflow_1_hour": outflows[0],
-        # "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
-        # "outflow_2_hour": outflows[1],
-        # "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
-        # "outflow_3_hour": outflows[2],
-        # "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
-        # "outflow_6_hour": outflows[3],
-        # "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
-        # "outflow_12_hour": outflows[4],
-        # "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
-        # "outflow_24_hour": outflows[5]
+        "time": unitHydrograph[3]['time'],
+        "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
+        "outflow_1_hour": outflows[0],
+        "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
+        "outflow_2_hour": outflows[1],
+        "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
+        "outflow_3_hour": outflows[2],
+        "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
+        "outflow_6_hour": outflows[3],
+        "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
+        "outflow_12_hour": outflows[4],
+        "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
+        "outflow_24_hour": outflows[5]
     }
+
+    # print(runoff_and_ponding_results)
+    # print(pond_inflow_and_outflow_ordinates)
 
     return runoff_and_ponding_results, pond_inflow_and_outflow_ordinates

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -4,23 +4,23 @@ from SC_Synthetic_UH_Method import computeSCSyntheticUnitHydrograph
 
 
 def calcStormPonds(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistributionCurve, PRF, CN, S, Ia,
-              pondOption, pond_bottom_elev, Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers, OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length , OS_Crest_EL , Seepage_Bottom, Seepage_Side,
+              pondOption, pond_bottom_elev, Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Weirs, OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length , OS_Crest_EL , Seepage_Bottom, Seepage_Side,
               length = None, w1 = None, w2 = None, side_slope_z = None, bottom_slope = None,
               Elev_Area = None):
         
     # lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistributionCurve, PRF, CN, S, Ia: see computeSCSyntheticUnitHydrograph
     # pondOption: 1 or 2 
-    # pond_bottom_elev: Elecation of pond bottom in feet
-    # Orif1_Coeff & Orif2_Coeff: Coefficent of 1st and 2nd stage circular orfices
-    # Orif1_Dia & Orif2_Dia: Diameter of 1st and 2nd stage circular orfices in inches
-    # Orif1_CtrEL & Orif2_CtrEL: Centerline elecation aboce bottom of pond for 1st and 2nd stage circular orfices in feet
-    # Orif1_NumOpenings & Orif2_NumOpenings: number of openings for 1st and 2nd stage circular orfices
-    # Rec_Weir_Coeff: 3rd stage rectangular weir coefficent 
+    # pond_bottom_elev: Elevation of pond bottom in feet
+    # Orif1_Coeff & Orif2_Coeff: coefficient of 1st and 2nd stage circular orifices
+    # Orif1_Dia & Orif2_Dia: Diameter of 1st and 2nd stage circular orifices in inches
+    # Orif1_CtrEL & Orif2_CtrEL: Centerline elevation above bottom of pond for 1st and 2nd stage circular orifices in feet
+    # Orif1_NumOpenings & Orif2_NumOpenings: number of openings for 1st and 2nd stage circular orifices
+    # Rec_Weir_Coeff: 3rd stage rectangular weir coefficient 
     # Rec_Weir_Ex: 3rd stage rectangular weir exponent 
     # Rec_Weir_Length: 3rd stage rectangular weir length in feet 
     # Rec_WeirCrest_EL: 3rd stage rectangular weir crest elevation above pond bottom in feet 
-    # Rec_Num_Wiers: number of weirs for 3rd stage rectangular weir
-    # OS_BCWeir_Coeff: broad-crested weird coefficent for overflow spillway 
+    # Rec_Num_Weirs: number of weirs for 3rd stage rectangular weir
+    # OS_BCWeir_Coeff: broad-crested weird coefficient for overflow spillway 
     # OS_Weir_Ex: weir exponent for overflow spillway
     # OS_Length: overflow spillway length in feet
     # OS_Crest_EL: crest elevation above pond bottom for overflow spillway in feet
@@ -34,7 +34,7 @@ def calcStormPonds(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistri
     # Elev_Area: list of values elevation (ft-MSL) vs surface area (sq ft), for pond option 2
 
 
-    # Caluclate Unit Hydrograph
+    # Calculate Unit Hydrograph
     unitHydrograph = computeSCSyntheticUnitHydrograph(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistributionCurve, PRF, CN, S, Ia)
 
     # Fixed Variables
@@ -58,7 +58,7 @@ def calcStormPonds(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistri
         Q, twoS_dtplusQ, Y = calcPondOne(length, w1, w2, side_slope_z, bottom_slope, pond_bottom_elev, 
                                         Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
                                         Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
-                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Weirs,
                                         OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
                                         Seepage_Bottom, Seepage_Side,
                                         max_depth, burst_duration)
@@ -69,14 +69,14 @@ def calcStormPonds(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistri
         Q, twoS_dtplusQ, Y = calcPondTwo(Elev_Area, pond_bottom_elev,
                                         Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
                                         Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
-                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Weirs,
                                         OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
                                         Seepage_Bottom, Seepage_Side,
                                         max_depth, burst_duration)
 
     # Calculate outflow (Q2) for each storm duration
-    for D in storm_duration:     # Loop thorugh storm_duration
-        # Initlaize arrays used in 
+    for D in storm_duration:     # Loop through storm_duration
+        # Initialize arrays used in 
         time = unitHydrograph[3]['time'] # pond_x hr(column B)
         inflow = unitHydrograph[3]['flow_' + str(D) + '_hour'] # pond_x hr (column C)
         i1plusi2 = [] # pond_x hr (column D)
@@ -192,7 +192,7 @@ def calcStormPonds(lat, lon, AEP, CNModificationMethod, Area, Tc, RainfallDistri
 def calcPondTwo(Elev_Area, pond_bottom_elev,
                 Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
                 Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
-                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Weirs,
                 OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
                 Seepage_Bottom, Seepage_Side,
                 max_depth, burst_duration):
@@ -200,31 +200,31 @@ def calcPondTwo(Elev_Area, pond_bottom_elev,
     if pond_bottom_elev != Elev_Area[0][0]:
         raise Exception("Bottom pond elevation must be the same as the first elevation input.")
         
-    # Initalize arrays used in 
+    # Initialize arrays used in 
     Q = [] # Pond_X hr, 2S_Dt, Y-Q (2) 
     S = [] # Pond_X, 2S_Dt+Q, Y-S (2)
     A = [] # Y-S (2)
     change_S = [] # Pond_X hr
     twoS_dtplusQ = [] # Y-S (2)
     Y = [] # Pond_X hr, 2S_Dt, Y-Q (2)
-    # Caluclate values in Y-Q (2) sheet
+    # Calculate values in Y-Q (2) sheet
     Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
     Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
     for y in range(0, max_depth):
         print(y)
         Y.append(y)
-        # First Stage Orfice Total Flow
+        # First Stage Orifice Total Flow
         Orif1_H = max(0,y-Orif1_CtrEL)
         Orif1_Q = max(0,Orif1_Coeff*Orif1_A*math.sqrt(64.4*Orif1_H))   
         Orif1_total_flow = Orif1_NumOpenings*Orif1_Q
-        # Second Stage Orfice Total Flow
+        # Second Stage Orifice Total Flow
         Orif2_H = max(0,y-Orif2_CtrEL)
         Orif2_Q = max(0,Orif2_Coeff*Orif2_A*math.sqrt(64.4*Orif2_H)) 
         Orif2_total_flow = Orif2_NumOpenings*Orif2_Q
         # Upper Stage Rectangular Weir Total Flow
         Rec_Weir_H = max(0,y-Rec_WeirCrest_EL)
         Rec_Single_Weir_Q = Rec_Weir_Coeff*Rec_Weir_Length*Rec_Weir_H**Rec_Weir_Ex
-        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Wiers
+        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Weirs
         # Overflow Spillway Q
         OS_H = max(0,y-OS_Crest_EL)
         OS_Q = OS_BCWeir_Coeff*OS_Length*OS_H**OS_Weir_Ex
@@ -266,10 +266,10 @@ def calcPondTwo(Elev_Area, pond_bottom_elev,
 def calcPondOne(length, w1, w2, side_slope_z, bottom_slope, pond_bottom_elev, 
                 Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
                 Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
-                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Weirs,
                 OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
                 Seepage_Bottom, Seepage_Side, max_depth, burst_duration):
-    # Initalize arrays used in 
+    # Initialize arrays used in 
     Q = [] # Pond_X hr, 2S_Dt, Y-Q (1) 
     S = [] # Pond_X, 2S_Dt+Q, Y-S (1)
     Total_L = [] # Y-S (1)
@@ -279,24 +279,24 @@ def calcPondOne(length, w1, w2, side_slope_z, bottom_slope, pond_bottom_elev,
     change_S = [] # Pond_X hr
     twoS_dtplusQ = [] # Y-S (1)
     Y = [] # Pond_X hr, 2S_Dt, Y-Q (1)
-    # Caluclate values in Y-Q (1) sheet
+    # Calculate values in Y-Q (1) sheet
     Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
     Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
     for y in range(0, max_depth+1):
         Y.append(y)
         h = pond_bottom_elev + y
-        # First Stage Orfice Total Flow
+        # First Stage Orifice Total Flow
         Orif1_H = max(0,y-Orif1_CtrEL)
         Orif1_Q = max(0,Orif1_Coeff*Orif1_A*math.sqrt(64.4*Orif1_H))   
         Orif1_total_flow = Orif1_NumOpenings*Orif1_Q
-        # Second Stage Orfice Total Flow
+        # Second Stage Orifice Total Flow
         Orif2_H = max(0,y-Orif2_CtrEL)
         Orif2_Q = max(0,Orif2_Coeff*Orif2_A*math.sqrt(64.4*Orif2_H)) 
         Orif2_total_flow = Orif2_NumOpenings*Orif2_Q
         # Upper Stage Rectangular Weir Total Flow
         Rec_Weir_H = max(0,y-Rec_WeirCrest_EL)
         Rec_Single_Weir_Q = Rec_Weir_Coeff*Rec_Weir_Length*Rec_Weir_H**Rec_Weir_Ex
-        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Wiers
+        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Weirs
         # Overflow Spillway Q
         OS_H = max(0,y-OS_Crest_EL)
         OS_Q = OS_BCWeir_Coeff*OS_Length*OS_H**OS_Weir_Ex

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -5,6 +5,8 @@ from SC_Synthetic_UH_Method import computeSCSyntheticUnitHydrograph
 
 def calcponds():
         
+    pondOption = 2
+
     # Fixed Variables
     storm_duration = [1, 2, 3, 6, 12, 24] # hours, referred to as a D-hour storm
     burst_duration = 6
@@ -20,15 +22,6 @@ def calcponds():
 
     # TODO: These all need to be upper inputs
     unitHydrograph = computeSCSyntheticUnitHydrograph(33.3946, -80.3474, 10, "Merkel", 100.0, 78, "II", 240, 66.9, 4.94, 0.99)
-
-    # pond 1
-    length = 200
-    w1 = 200
-    w2 = 200
-    side_slope_z = 3
-    bottom_slope = .5
-
-    # pond 2
 
     # both
     pond_bottom_elev = 100
@@ -52,6 +45,230 @@ def calcponds():
     Seepage_Bottom = 2
     Seepage_Side = 4
 
+    # pond 1
+    length = 200
+    w1 = 200
+    w2 = 200
+    side_slope_z = 3
+    bottom_slope = .5
+
+    # pond 2
+    Elev_Area = [[100, 2000], [101,2100],[102,2200],[103,2400],[104, 2900],[105,3300],[106,3700],[107,4000],[108,4400],[109,4800]]
+
+    if pondOption == 1:
+        Q, twoS_dtplusQ, Y = calcPondOne(length, w1, w2, side_slope_z, bottom_slope, pond_bottom_elev, 
+                                        Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
+                                        Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
+                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                                        OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
+                                        Seepage_Bottom, Seepage_Side,
+                                        max_depth, burst_duration)
+    else:    
+        Q, twoS_dtplusQ, Y = calcPondTwo(Elev_Area, pond_bottom_elev,
+                                        Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
+                                        Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
+                                        Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                                        OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
+                                        Seepage_Bottom, Seepage_Side,
+                                        max_depth, burst_duration)
+
+
+    outflows = []
+    # Loop thorugh storm_duration
+    for D in storm_duration:
+        # Initlaize arrays used in 
+        time = unitHydrograph[3]['time'] # pond_x hr(column B)
+        inflow = unitHydrograph[3]['flow_' + str(D) + '_hour'] # pond_x hr (column C)
+        i1plusi2 = [] # pond_x hr (column D)
+        twoS_dtplusQ2 = [] # pond_x hr (column F)
+        twoS_dtminusQ1 = [] # pond_x hr (column E)
+        Q2 = [] # pond_x hr (column H) & D-hr Storm Pond Routing Results
+        Y2 = [] # pond_x hr (column G)
+        counter = 0
+    
+        for t in time:
+            if counter == 0:
+                i1plusi2.append(0)
+                twoS_dtminusQ1.append(0)
+                twoS_dtplusQ2.append(0)
+                Y2.append(0)
+                Q2.append(0)
+            else:
+                i1plusi2.append(inflow[counter-1] + inflow[counter])
+                twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
+                twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
+                # Q2 & Y2
+                if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
+                    Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
+                    Y2.append(Y[0]+((Y[1]-Y[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
+                    Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
+                    Y2.append(Y[1]+((Y[2]-Y[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
+                    Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
+                    Y2.append(Y[2]+((Y[3]-Y[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]): 
+                    Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
+                    Y2.append(Y[3]+((Y[4]-Y[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
+                    Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
+                    Y2.append(Y[4]+((Y[5]-Y[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
+                    Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
+                    Y2.append(Y[5]+((Y[6]-Y[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
+                    Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
+                    Y2.append(Y[6]+((Y[7]-Y[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
+                    Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
+                    Y2.append(Y[7]+((Y[8]-Y[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
+                    Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))
+                    Y2.append(Y[8]+((Y[9]-Y[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))  
+                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
+                    Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
+                    Y2.append(Y[9]+((Y[10]-Y[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
+                else:
+                    Q2.append('error') 
+                    Y2.append('error')
+            counter = counter + 1
+        outflows.append(Q2)
+        
+        index_pond_peak_inflow = np.argmax(inflow)
+        pond_peak_inflow.append((inflow[index_pond_peak_inflow]))
+        time_of_pond_peak_inflow.append(time[index_pond_peak_inflow])
+        index_pond_peak_outflow = np.argmax(Q2)
+        pond_peak_outflow.append(Q2[index_pond_peak_outflow])
+        time_of_pond_peak_outflow.append(time[index_pond_peak_outflow])
+        pond_max_depth.append(max(Y2))
+        # print('time:', time)
+        # print('inflow:', inflow)
+        # print('i1plusi2:', i1plusi2)
+        # print('twoS_dtminusQ1:', twoS_dtminusQ1)
+        # print('twoS_dtplusQ2:', twoS_dtplusQ2)
+        # print('Q2:', Q2)
+        # print('Y2:', Y2)
+    
+    # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
+    index_max_peak_outflow = np.argmax(pond_peak_outflow)
+    max_peak_outflow = storm_duration[index_max_peak_outflow]
+
+    runoff_and_ponding_results = {
+        "storm_duration": unitHydrograph[2]['storm_duration'],
+        "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
+        "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  
+        "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
+        "pond_peak_inflow": pond_peak_inflow, # max of inflow (pond_x hr 19)
+        "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow (pond_x hr k20)
+        "pond_peak_outflow": pond_peak_outflow, # max of outflow (pond_x hr k22)
+        "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow (pond_x hr k23)
+        "max_peak_outflow_storm_duration": max_peak_outflow, # storm duration with max peak outflow
+        "max_depth": pond_max_depth # max_depth (pond_x hr k24)
+    }
+
+    pond_inflow_and_outflow_ordinates = {
+        "time": unitHydrograph[3]['time'],
+        "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
+        "outflow_1_hour": outflows[0],
+        "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
+        "outflow_2_hour": outflows[1],
+        "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
+        "outflow_3_hour": outflows[2],
+        "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
+        "outflow_6_hour": outflows[3],
+        "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
+        "outflow_12_hour": outflows[4],
+        "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
+        "outflow_24_hour": outflows[5]
+    }
+
+    # print(runoff_and_ponding_results)
+    # print(pond_inflow_and_outflow_ordinates)
+
+    return runoff_and_ponding_results, pond_inflow_and_outflow_ordinates
+
+
+# Pond option two calculations
+def calcPondTwo(Elev_Area, pond_bottom_elev,
+                Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
+                Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
+                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
+                Seepage_Bottom, Seepage_Side,
+                max_depth, burst_duration):
+    
+    if pond_bottom_elev != Elev_Area[0][0]:
+        raise Exception("Bottom pond elevation must be the same as the first elevation input.")
+        
+    # Initalize arrays used in 
+    Q = [] # Pond_X hr, 2S_Dt, Y-Q (2) 
+    S = [] # Pond_X, 2S_Dt+Q, Y-S (2)
+    A = [] # Y-S (2)
+    change_S = [] # Pond_X hr
+    twoS_dtplusQ = [] # Y-S (2)
+    Y = [] # Pond_X hr, 2S_Dt, Y-Q (2)
+    # Caluclate values in Y-Q (2) sheet
+    Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
+    Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
+    for y in range(0, max_depth):
+        print(y)
+        Y.append(y)
+        # First Stage Orfice Total Flow
+        Orif1_H = max(0,y-Orif1_CtrEL)
+        Orif1_Q = max(0,Orif1_Coeff*Orif1_A*math.sqrt(64.4*Orif1_H))   
+        Orif1_total_flow = Orif1_NumOpenings*Orif1_Q
+        # Second Stage Orfice Total Flow
+        Orif2_H = max(0,y-Orif2_CtrEL)
+        Orif2_Q = max(0,Orif2_Coeff*Orif2_A*math.sqrt(64.4*Orif2_H)) 
+        Orif2_total_flow = Orif2_NumOpenings*Orif2_Q
+        # Upper Stage Rectangular Weir Total Flow
+        Rec_Weir_H = max(0,y-Rec_WeirCrest_EL)
+        Rec_Single_Weir_Q = Rec_Weir_Coeff*Rec_Weir_Length*Rec_Weir_H**Rec_Weir_Ex
+        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Wiers
+        # Overflow Spillway Q
+        OS_H = max(0,y-OS_Crest_EL)
+        OS_Q = OS_BCWeir_Coeff*OS_Length*OS_H**OS_Weir_Ex
+        # Seepage in cfs
+        if y == 0:
+            A1 = Elev_Area[0][1]
+            A.append(A1)
+        else:
+            A.append(Elev_Area[y][1])
+        if y == 0:
+            Seepage_Bottom_CFS = 0
+            Seepage_Side_CFS = 0
+        else:
+            Seepage_Bottom_CFS = A1*Seepage_Bottom/(12*3600)
+            Seepage_Side_CFS = (A[y]-A1)*Seepage_Side/(12*3600)
+        
+        # Calculate Q in 2S_Dt+Q & Pond_X hr sheets
+        Outflow_Q = Orif1_total_flow+Orif2_total_flow+Rec_Stage_total_flow+OS_Q+Seepage_Bottom_CFS+Seepage_Side_CFS
+        Q.append(Outflow_Q) 
+        # Calculate S in 2S_Dt+Q & Pond_X hr sheets; Calculate change in S from Y-S (2) sheet 
+        if y == 0:
+            S.append(0)
+            change_S.append(0)
+        else:
+            change_S.append(((A[y-1]+A[y])/2)*(Y[y] - Y[y-1])) 
+            S.append(S[y-1] + change_S[y])
+        # Calculate 2S/dt+Q in 2S_Dt+Q & Pond_X hr sheets
+        twoS_dtplusQ.append((2*S[y]/(60*burst_duration))+Q[y])
+
+    # print('Q:', Q) 
+    # print('S:', S)
+    # print('twoS_dtplusQ:', twoS_dtplusQ)
+    # print('Y:', Y)
+
+    return(Q, twoS_dtplusQ, Y)
+
+
+# Pond option one calculations
+def calcPondOne(length, w1, w2, side_slope_z, bottom_slope, pond_bottom_elev, 
+                Orif1_Coeff, Orif1_Dia, Orif1_CtrEL, Orif1_NumOpenings, 
+                Orif2_Coeff, Orif2_Dia, Orif2_CtrEL, Orif2_NumOpenings, 
+                Rec_Weir_Coeff, Rec_Weir_Ex, Rec_Weir_Length, Rec_WeirCrest_EL, Rec_Num_Wiers,
+                OS_BCWeir_Coeff, OS_Weir_Ex, OS_Length, OS_Crest_EL,
+                Seepage_Bottom, Seepage_Side, max_depth, burst_duration):
     # Initalize arrays used in 
     Q = [] # Pond_X hr, 2S_Dt, Y-Q (1) 
     S = [] # Pond_X, 2S_Dt+Q, Y-S (1)
@@ -59,7 +276,7 @@ def calcponds():
     Total_W1 = [] # Y-S (1)
     Total_W2 = [] # Y-S (1)
     A = [] # Y-S (1)
-    change_S = [] # Pond_1 hr
+    change_S = [] # Pond_X hr
     twoS_dtplusQ = [] # Y-S (1)
     Y = [] # Pond_X hr, 2S_Dt, Y-Q (1)
     # Caluclate values in Y-Q (1) sheet
@@ -115,135 +332,11 @@ def calcponds():
         # Calculate 2S/dt+Q in 2S_Dt+Q & Pond_X hr sheets
         twoS_dtplusQ.append((2*S[y]/(60*burst_duration))+Q[y])
 
-        
-
     # print('Q:', Q) 
     # print('S:', S)
     # print('twoS_dtplusQ:', twoS_dtplusQ)
     # print('Y:', Y)
 
-    outflows = []
-    # Loop thorugh storm_duration
-    for D in storm_duration:
-        # Initlaize arrays used in 
-        time = unitHydrograph[3]['time'] # pond_x hr(column B)
-        inflow = unitHydrograph[3]['flow_' + str(D) + '_hour'] # pond_x hr (column C)
-        i1plusi2 = [] # pond_x hr (column D)
-        twoS_dtplusQ2 = [] # pond_x hr (column F)
-        twoS_dtminusQ1 = [] # pond_x hr (column E)
-        Q2 = [] # pond_x hr (column H) & D-hr Storm Pond Routing Results
-        Y2 = [] # pond_x hr (column G)
-        counter = 0
-    
-        for t in time:
-            if counter == 0:
-                i1plusi2.append(0)
-                twoS_dtminusQ1.append(0)
-                twoS_dtplusQ2.append(0)
-                Y2.append(0)
-                Q2.append(0)
-            else:
-                i1plusi2.append(inflow[counter-1] + inflow[counter])
-                twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
-                twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
-                # Q2 & Y2
-                if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
-                    print(1)
-                    Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
-                    Y2.append(Y[0]+((Y[1]-Y[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[0]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
-                    Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
-                    Y2.append(Y[1]+((Y[2]-Y[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[1]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
-                    print(3)
-                    Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
-                    Y2.append(Y[2]+((Y[3]-Y[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[2]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]): 
-                    print(4)                
-                    Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
-                    Y2.append(Y[3]+((Y[4]-Y[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[3]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
-                    print(5)
-                    Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
-                    Y2.append(Y[4]+((Y[5]-Y[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[4]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
-                    print(6)
-                    Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
-                    Y2.append(Y[5]+((Y[6]-Y[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[5]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
-                    print(7)
-                    Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
-                    Y2.append(Y[6]+((Y[7]-Y[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[6]))
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
-                    print(8)
-                    Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
-                    Y2.append(Y[7]+((Y[8]-Y[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[7])) 
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
-                    print(9)
-                    Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))
-                    Y2.append(Y[8]+((Y[9]-Y[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[8]))  
-                elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
-                    print(10)
-                    Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
-                    Y2.append(Y[9]+((Y[10]-Y[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ[9])) 
-                else:
-                    Q2.append('error') 
-                    Y2.append('error')
-            counter = counter + 1
-        outflows.append(Q2)
+    return(Q, twoS_dtplusQ, Y)
         
-        index_pond_peak_inflow = np.argmax(inflow)
-        pond_peak_inflow.append((inflow[index_pond_peak_inflow]))
-        time_of_pond_peak_inflow.append(time[index_pond_peak_inflow])
-        index_pond_peak_outflow = np.argmax(Q2)
-        pond_peak_outflow.append(Q2[index_pond_peak_outflow])
-        time_of_pond_peak_outflow.append(time[index_pond_peak_outflow])
-        pond_max_depth.append(max(Y2))
-        # print('time:', time)
-        # print('inflow:', inflow)
-        # print('i1plusi2:', i1plusi2)
-        # print('twoS_dtminusQ1:', twoS_dtminusQ1)
-        # print('twoS_dtplusQ2:', twoS_dtplusQ2)
-        # print('Q2:', Q2)
-        # print('Y2:', Y2)
-    
 
-    
-
-    # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
-    index_max_peak_outflow = np.argmax(pond_peak_outflow)
-    max_peak_outflow = storm_duration[index_max_peak_outflow]
-
-    runoff_and_ponding_results = {
-        "storm_duration": unitHydrograph[2]['storm_duration'],
-        "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
-        "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  
-        "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
-        "pond_peak_inflow": pond_peak_inflow, # max of inflow (pond_x hr 19)
-        "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow (pond_x hr k20)
-        "pond_peak_outflow": pond_peak_outflow, # max of outflow (pond_x hr k22)
-        "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow (pond_x hr k23)
-        "max_peak_outflow_storm_duration": max_peak_outflow, # storm duration with max peak outflow
-        "max_depth": pond_max_depth # max_depth (pond_x hr k24)
-    }
-
-    pond_inflow_and_outflow_ordinates = {
-        "time": unitHydrograph[3]['time'],
-        "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
-        "outflow_1_hour": outflows[0],
-        "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
-        "outflow_2_hour": outflows[1],
-        "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
-        "outflow_3_hour": outflows[2],
-        "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
-        "outflow_6_hour": outflows[3],
-        "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
-        "outflow_12_hour": outflows[4],
-        "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
-        "outflow_24_hour": outflows[5]
-    }
-
-    # print(runoff_and_ponding_results)
-    # print(pond_inflow_and_outflow_ordinates)
-
-    return runoff_and_ponding_results, pond_inflow_and_outflow_ordinates

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -211,7 +211,6 @@ def calcPondTwo(Elev_Area, pond_bottom_elev,
     Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
     Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
     for y in range(0, max_depth):
-        print(y)
         Y.append(y)
         # First Stage Orifice Total Flow
         Orif1_H = max(0,y-Orif1_CtrEL)

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -1,0 +1,149 @@
+import math
+import numpy as np
+from SC_Synthetic_UH_Method import computeSCSyntheticUnitHydrograph
+
+
+def calcponds():
+    
+    
+    storm_duration = [1, 2, 3, 6, 12, 24] # hours, referred to as a D-hour storm
+    burst_duration = 6
+    max_depth = 10
+
+    pond_peak_inflow = []
+    time_of_pond_peak_inflow = []
+    pond_peak_outflow = []
+    time_of_pond_peak_outflow = []
+
+    unitHydrograph = computeSCSyntheticUnitHydrograph(33.3946, -80.3474, 4, "Merkel", 100.0, 78, "II", 240, 66.9, 4.94, 0.99)
+
+    #pond 1
+    length = 200
+    w1 = 200
+    w2 = 200
+    side_slope_z = 3
+    bottom_slope = .5
+
+    #pond 2
+
+    #both
+    pond_bottom_elev = 100
+    Orif1_Coeff=.6
+    Orif1_Dia = 6
+    Orif1_CtrEL = .5
+    Orif1_NumOpenings = 1
+    Orif2_Coeff=.6
+    Orif2_Dia = 6
+    Orif2_CtrEL = 2
+    Orif2_NumOpenings = 1
+    Rec_Weir_Coeff = 3.3
+    Rec_Weir_Ex = 1.5
+    Rec_Weir_Length = 2
+    Rec_WeirCrest_EL = 4
+    Rec_Num_Wiers = 1
+    OS_BCWeir_Coeff = 3
+    OS_Weir_Ex = 1.5
+    OS_Length = 20
+    OS_Crest_EL = 6
+    Seepage_Bottom = 2
+    Seepage_Side = 4
+
+# Iterate over all the D-hour storms
+    
+    Q = []
+    S = []
+    Total_L = []
+    Total_W1 = []
+    Total_W2 = []
+    A = []
+    change_S = []
+    
+    Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
+    Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
+    for Y in range(0, max_depth+1):
+        h = pond_bottom_elev + Y
+        # First Stage Orfice Total Flow
+        Orif1_H = max(0,Y-Orif1_CtrEL)
+        Orif1_Q = max(0,Orif1_Coeff*Orif1_A*math.sqrt(64.4*Orif1_H))   
+        Orif1_total_flow = Orif1_NumOpenings*Orif1_Q
+        # Second Stage Orfice Total Flow
+        Orif2_H = max(0,Y-Orif2_CtrEL)
+        Orif2_Q = max(0,Orif2_Coeff*Orif2_A*math.sqrt(64.4*Orif2_H)) 
+        Orif2_total_flow = Orif2_NumOpenings*Orif2_Q
+        # Upper Stage Rectangular Weir Total Flow
+        Rec_Weir_H = max(0,Y-Rec_WeirCrest_EL)
+        Rec_Single_Weir_Q = Rec_Weir_Coeff*Rec_Weir_Length*Rec_Weir_H**Rec_Weir_Ex
+        Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Wiers
+        # Overflow Spillway Q
+        OS_H = max(0,Y-OS_Crest_EL)
+        OS_Q = OS_BCWeir_Coeff*OS_Length*OS_H**OS_Weir_Ex
+        # Calculate Seepage in cfs
+        if Y == 0:
+            Total_L.append(length+2*bottom_slope*(h-pond_bottom_elev))
+            Total_W1.append(w1+2*side_slope_z*(h-pond_bottom_elev))
+            Total_W2.append(w2+2*side_slope_z*(h-pond_bottom_elev))
+            A1 = Total_L[Y]*(Total_W1[Y]+Total_W2[Y])/2
+            A.append(A1)
+        else:
+            Total_L.append(Total_L[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
+            Total_W1.append(Total_W1[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
+            Total_W2.append(Total_W2[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
+            A.append(Total_L[Y]*(Total_W1[Y]+Total_W2[Y])/2)
+        if Y == 0:
+            Seepage_Bottom_CFS = 0
+            Seepage_Side_CFS = 0
+        else:
+            Seepage_Bottom_CFS = A1*Seepage_Bottom/(12*3600)
+            Seepage_Side_CFS = (A[Y]-A1)*Seepage_Side/(12*3600)
+
+        Outflow_Q = Orif1_total_flow+Orif2_total_flow+Rec_Stage_total_flow+OS_Q+Seepage_Bottom_CFS+Seepage_Side_CFS
+        Q.append(Outflow_Q) 
+
+        if Y == 0:
+            S.append(0)
+            change_S.append(0)
+        else:
+            change_S.append(((A[Y-1]+A[Y])/2)*(1)) # not sure if it will always be (1)
+            S.append(S[Y-1] + change_S[Y])
+        
+
+    print(Q) 
+    print(S)
+   
+
+    
+        
+    # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
+    #index_max_peak_outflow = np.argmax(pond_peak_outflow)
+    #max_peak_outflow = storm_duration[index_max_peak_outflow]
+    max_peak_outflow = 6
+
+    runoff_and_ponding_results = {
+        "storm_duration": unitHydrograph[2]['storm_duration'],
+        "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
+        "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  # I think the spreadsheet is wrong here 
+        "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
+        "pond_peak_inflow": pond_peak_inflow, # max of inflow
+        "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow
+        "pond_peak_outflow": pond_peak_outflow, # max of outflow
+        "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow
+        "max_peak_outflow_storm_duration": max_peak_outflow # storm duration with max peak outflow
+    }
+
+    pond_inflow_and_outflow_ordinates = {
+        "time": unitHydrograph[3]['time'],
+        "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
+        "outflow_1_hour": None,
+        "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
+        "outflow_2_hour": None,
+        "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
+        "outflow_3_hour": None,
+        "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
+        "outflow_6_hour": None,
+        "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
+        "outflow_12_hour": None,
+        "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
+        "outflow_24_hour": None
+    }
+
+    return runoff_and_ponding_results, pond_inflow_and_outflow_ordinates

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -4,8 +4,7 @@ from SC_Synthetic_UH_Method import computeSCSyntheticUnitHydrograph
 
 
 def calcponds():
-    
-    
+        
     # Fixed Variables
     storm_duration = [1, 2, 3, 6, 12, 24] # hours, referred to as a D-hour storm
     burst_duration = 6
@@ -16,6 +15,7 @@ def calcponds():
     time_of_pond_peak_inflow = []
     pond_peak_outflow = []
     time_of_pond_peak_outflow = []
+    pond_max_depth = []
 
 
     # TODO: These all need to be upper inputs
@@ -125,24 +125,59 @@ def calcponds():
     # Initlaize arrays used in 
     time = unitHydrograph[3]['time'] # pond_x hr
     inflow = unitHydrograph[3]['flow_1_hour'] # pond_x hr TODO depends on storm_duration loop
-    i1plusi2 = [] # pond_x hr
-    twoS_dtplusQ2 = [] # pond_x hr
-    twoS_dtminusQ2 = [] # pond_x hr
-    outflow = [] # pond_x hr (as Q2) & D-hr Storm Pond Routing Results
+    i1plusi2 = [] # pond_x hr (column E)
+    twoS_dtplusQ2 = [] # pond_x hr (column F)
+    twoS_dtminusQ1 = [] # pond_x hr (column E)
+    Q2 = [] # pond_x hr (column H)
+    Y2 = [] # pond_x hr (column G)
+    outflows = [] # pond_x hr (as Q2) & D-hr Storm Pond Routing Results
     counter = 0
+
+
 
     for t in time:
         if counter == 0:
             i1plusi2.append(0)
+            twoS_dtminusQ1.append(0)
+            twoS_dtplusQ2.append(0)
+            Y2.append(0)
+            Q2.append(0)
         else:
             i1plusi2.append(inflow[counter-1] + inflow[counter])
-
+            twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
+            twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
+            # Q2
+            if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
+                Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[0]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
+                Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[1]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
+                Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[2]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]):                 
+                Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[3]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
+                Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[4]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
+                Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[5]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
+                Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[6]))
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
+                Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[7])) 
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
+                Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8])) 
+            elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
+                Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[9])) 
+            else:
+                Q2.append('error') 
+            # Y2
         counter = counter + 1
 
-    print(time)
-    print(inflow)
-    print(i1plusi2)
-
+    print('time:', time)
+    print('inflow:', inflow)
+    print('i1plusi2:', i1plusi2)
+    print('twoS_dtminusQ1:', twoS_dtminusQ1)
+    print('twoS_dtplusQ2:', twoS_dtplusQ2)
+    print('Q2:', Q2)
 
     # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
     #index_max_peak_outflow = np.argmax(pond_peak_outflow)
@@ -150,31 +185,32 @@ def calcponds():
     max_peak_outflow = 6
 
     runoff_and_ponding_results = {
-        "storm_duration": unitHydrograph[2]['storm_duration'],
-        "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
-        "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  # I think the spreadsheet is wrong here 
-        "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
-        "pond_peak_inflow": pond_peak_inflow, # max of inflow
-        "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow
-        "pond_peak_outflow": pond_peak_outflow, # max of outflow
-        "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow
-        "max_peak_outflow_storm_duration": max_peak_outflow # storm duration with max peak outflow
+        # "storm_duration": unitHydrograph[2]['storm_duration'],
+        # "rainfall_depth": unitHydrograph[2]['rainfall_depth'],
+        # "CN_adjusted_for_rainfall_duration": unitHydrograph[2]['CN_adjusted_for_rainfall_duration'],  # I think the spreadsheet is wrong here 
+        # "runoff_volume_Q_CN": unitHydrograph[2]['runoff_volume_Q_CN'],
+        # "pond_peak_inflow": pond_peak_inflow, # max of inflow (pond_x hr 19)
+        # "time_of_pond_peak_inflow": time_of_pond_peak_inflow, # time of max inflow (pond_x hr k20)
+        # "pond_peak_outflow": pond_peak_outflow, # max of outflow (pond_x hr k22)
+        # "time_of_pond_peak_outflow": time_of_pond_peak_outflow, # time of max outflow (pond_x hr k23)
+        # "max_peak_outflow_storm_duration": max_peak_outflow, # storm duration with max peak outflow
+        # "max_depth": pond_max_depth # max_depth (pond_x hr k24)
     }
 
     pond_inflow_and_outflow_ordinates = {
-        "time": unitHydrograph[3]['time'],
-        "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
-        "outflow_1_hour": None,
-        "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
-        "outflow_2_hour": None,
-        "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
-        "outflow_3_hour": None,
-        "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
-        "outflow_6_hour": None,
-        "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
-        "outflow_12_hour": None,
-        "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
-        "outflow_24_hour": None
+        # "time": unitHydrograph[3]['time'],
+        # "inflow_1_hour": unitHydrograph[3]['flow_1_hour'],
+        # "outflow_1_hour": outflows[0],
+        # "inflow_2_hour": unitHydrograph[3]['flow_2_hour'],
+        # "outflow_2_hour": outflows[1],
+        # "inflow_3_hour": unitHydrograph[3]['flow_3_hour'],
+        # "outflow_3_hour": outflows[2],
+        # "inflow_6_hour": unitHydrograph[3]['flow_6_hour'],
+        # "outflow_6_hour": outflows[3],
+        # "inflow_12_hour": unitHydrograph[3]['flow_12_hour'],
+        # "outflow_12_hour": outflows[4],
+        # "inflow_24_hour": unitHydrograph[3]['flow_24_hour'],
+        # "outflow_24_hour": outflows[5]
     }
 
     return runoff_and_ponding_results, pond_inflow_and_outflow_ordinates

--- a/Storm_Ponds.py
+++ b/Storm_Ponds.py
@@ -61,65 +61,66 @@ def calcponds():
     A = [] # Y-S (1)
     change_S = [] # Pond_1 hr
     twoS_dtplusQ = [] # Y-S (1)
-
+    Y = []
     # Caluclate values in Y-Q (1) sheet
     Orif1_A = 3.14159*((Orif1_Dia/12)**2)/4
     Orif2_A = 3.14159*((Orif2_Dia/12)**2)/4
-    for Y in range(0, max_depth+1):
-        h = pond_bottom_elev + Y
+    for y in range(0, max_depth+1):
+        Y.append(y)
+        h = pond_bottom_elev + y
         # First Stage Orfice Total Flow
-        Orif1_H = max(0,Y-Orif1_CtrEL)
+        Orif1_H = max(0,y-Orif1_CtrEL)
         Orif1_Q = max(0,Orif1_Coeff*Orif1_A*math.sqrt(64.4*Orif1_H))   
         Orif1_total_flow = Orif1_NumOpenings*Orif1_Q
         # Second Stage Orfice Total Flow
-        Orif2_H = max(0,Y-Orif2_CtrEL)
+        Orif2_H = max(0,y-Orif2_CtrEL)
         Orif2_Q = max(0,Orif2_Coeff*Orif2_A*math.sqrt(64.4*Orif2_H)) 
         Orif2_total_flow = Orif2_NumOpenings*Orif2_Q
         # Upper Stage Rectangular Weir Total Flow
-        Rec_Weir_H = max(0,Y-Rec_WeirCrest_EL)
+        Rec_Weir_H = max(0,y-Rec_WeirCrest_EL)
         Rec_Single_Weir_Q = Rec_Weir_Coeff*Rec_Weir_Length*Rec_Weir_H**Rec_Weir_Ex
         Rec_Stage_total_flow = Rec_Single_Weir_Q*Rec_Num_Wiers
         # Overflow Spillway Q
-        OS_H = max(0,Y-OS_Crest_EL)
+        OS_H = max(0,y-OS_Crest_EL)
         OS_Q = OS_BCWeir_Coeff*OS_Length*OS_H**OS_Weir_Ex
         # Seepage in cfs
-        if Y == 0:
+        if y == 0:
             Total_L.append(length+2*bottom_slope*(h-pond_bottom_elev))
             Total_W1.append(w1+2*side_slope_z*(h-pond_bottom_elev))
             Total_W2.append(w2+2*side_slope_z*(h-pond_bottom_elev))
-            A1 = Total_L[Y]*(Total_W1[Y]+Total_W2[Y])/2
+            A1 = Total_L[y]*(Total_W1[y]+Total_W2[y])/2
             A.append(A1)
         else:
-            Total_L.append(Total_L[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
-            Total_W1.append(Total_W1[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
-            Total_W2.append(Total_W2[Y-1]+2*side_slope_z*(1)) # not sure if it will always be (1)
-            A.append(Total_L[Y]*(Total_W1[Y]+Total_W2[Y])/2)
-        if Y == 0:
+            Total_L.append(Total_L[y-1]+2*side_slope_z*(Y[y] - Y[y-1])) 
+            Total_W1.append(Total_W1[y-1]+2*side_slope_z*(Y[y] - Y[y-1]))
+            Total_W2.append(Total_W2[y-1]+2*side_slope_z*(Y[y] - Y[y-1]))
+            A.append(Total_L[y]*(Total_W1[y]+Total_W2[y])/2)
+        if y == 0:
             Seepage_Bottom_CFS = 0
             Seepage_Side_CFS = 0
         else:
             Seepage_Bottom_CFS = A1*Seepage_Bottom/(12*3600)
-            Seepage_Side_CFS = (A[Y]-A1)*Seepage_Side/(12*3600)
+            Seepage_Side_CFS = (A[y]-A1)*Seepage_Side/(12*3600)
         
         # Calculate Q in 2S_Dt+Q & Pond_X hr sheets
         Outflow_Q = Orif1_total_flow+Orif2_total_flow+Rec_Stage_total_flow+OS_Q+Seepage_Bottom_CFS+Seepage_Side_CFS
         Q.append(Outflow_Q) 
         # Calculate S in 2S_Dt+Q & Pond_X hr sheets; Calculate change in S from Y-S (1) sheet 
-        if Y == 0:
+        if y == 0:
             S.append(0)
             change_S.append(0)
         else:
-            change_S.append(((A[Y-1]+A[Y])/2)*(1)) # not sure if it will always be (1)
-            S.append(S[Y-1] + change_S[Y])
+            change_S.append(((A[y-1]+A[y])/2)*(Y[y] - Y[y-1])) 
+            S.append(S[y-1] + change_S[y])
         # Calculate 2S/dt+Q in 2S_Dt+Q & Pond_X hr sheets
-        twoS_dtplusQ.append((2*S[Y]/(60*burst_duration))+Q[Y])
+        twoS_dtplusQ.append((2*S[y]/(60*burst_duration))+Q[y])
 
         
 
     print(Q) 
     print(S)
     print(twoS_dtplusQ)
-   
+    print('Y:', Y)
 
     # TODO Loop thorugh storm_duration
     # Initlaize arrays used in 
@@ -146,30 +147,40 @@ def calcponds():
             i1plusi2.append(inflow[counter-1] + inflow[counter])
             twoS_dtminusQ1.append(twoS_dtplusQ2[counter-1]-2*Q2[counter-1])
             twoS_dtplusQ2.append(i1plusi2[counter]+twoS_dtminusQ1[counter])
-            # Q2
+            # Q2 & Y2
             if (twoS_dtplusQ2[counter]<twoS_dtplusQ[1]):
                 Q2.append(Q[0]+((Q[1]-Q[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[0]))
+                Y2.append(Y[0]+((Y[1]-Y[0])/(twoS_dtplusQ[1]-twoS_dtplusQ[0]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[0]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[2]):  
                 Q2.append(Q[1]+((Q[2]-Q[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[1]))
+                Y2.append(Y[1]+((Y[2]-Y[1])/(twoS_dtplusQ[2]-twoS_dtplusQ[1]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[1]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[3]):  
                 Q2.append(Q[2]+((Q[3]-Q[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[2]))
+                Y2.append(Y[2]+((Y[3]-Y[2])/(twoS_dtplusQ[3]-twoS_dtplusQ[2]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[2]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[4]):                 
                 Q2.append(Q[3]+((Q[4]-Q[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[3]))
+                Y2.append(Y[3]+((Y[4]-Y[3])/(twoS_dtplusQ[4]-twoS_dtplusQ[3]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[3]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[5]):  
                 Q2.append(Q[4]+((Q[5]-Q[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[4]))
+                Y2.append(Y[4]+((Y[5]-Y[4])/(twoS_dtplusQ[5]-twoS_dtplusQ[4]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[4]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[6]):  
                 Q2.append(Q[5]+((Q[6]-Q[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[5]))
+                Y2.append(Y[5]+((Y[6]-Y[5])/(twoS_dtplusQ[6]-twoS_dtplusQ[5]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[5]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[7]):  
                 Q2.append(Q[6]+((Q[7]-Q[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[6]))
+                Y2.append(Y[6]+((Y[7]-Y[6])/(twoS_dtplusQ[7]-twoS_dtplusQ[6]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[6]))
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[8]): 
                 Q2.append(Q[7]+((Q[8]-Q[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[7])) 
+                Y2.append(Y[7]+((Y[8]-Y[7])/(twoS_dtplusQ[8]-twoS_dtplusQ[7]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[7])) 
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[9]):  
-                Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8])) 
+                Q2.append(Q[8]+((Q[9]-Q[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8]))
+                Y2.append(Y[8]+((Y[9]-Y[8])/(twoS_dtplusQ[9]-twoS_dtplusQ[8]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[8]))  
             elif (twoS_dtplusQ2[counter]<twoS_dtplusQ[10]): 
                 Q2.append(Q[9]+((Q[10]-Q[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[9])) 
+                Y2.append(Y[9]+((Y[10]-Y[9])/(twoS_dtplusQ[10]-twoS_dtplusQ[9]))*(twoS_dtplusQ2[counter]-twoS_dtplusQ2[9])) 
             else:
                 Q2.append('error') 
-            # Y2
+                Y2.append('error')
         counter = counter + 1
 
     print('time:', time)
@@ -178,6 +189,7 @@ def calcponds():
     print('twoS_dtminusQ1:', twoS_dtminusQ1)
     print('twoS_dtplusQ2:', twoS_dtplusQ2)
     print('Q2:', Q2)
+    print('Y2:', Y2)
 
     # Corresponds red arrow in the "D-hr Storm Pond Results" sheet
     #index_max_peak_outflow = np.argmax(pond_peak_outflow)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import FastAPI, HTTPException, Response, Body
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -506,44 +506,87 @@ class calculateStormPonds(BaseModel):
     
     class Config:
         schema_extra = {
-            "example": {
-                "lat": 33.3946,
-                "lon": -80.3474,
-                "AEP": 4,
-                "CNModificationMethod": "Merkel",
-                "Area": 100.0,
-                "Tc": 64.5,
-                "RainfallDistributionCurve": "II",
-                "PRF": 240,
-                "CN": 67.3,
-                "S": 4.86,
-                "Ia": 0.97,
-                "pondOption": 1,
-                "pond_bottom_elev": 100,
-                "Orif1_Coeff":.6,
-                "Orif1_Dia": 6,
-                "Orif1_CtrEL": .5,
-                "Orif1_NumOpenings": 1,
-                "Orif2_Coeff": .6,
-                "Orif2_Dia": 6,
-                "Orif2_CtrEL": 2,
-                "Orif2_NumOpenings": 1,
-                "Rec_Weir_Coeff": 3.3,
-                "Rec_Weir_Ex": 1.5,
-                "Rec_Weir_Length": 2,
-                "Rec_WeirCrest_EL": 4,
-                "Rec_Num_Weirs": 1,
-                "OS_BCWeir_Coeff": 3,
-                "OS_Weir_Ex": 1.5,
-                "OS_Length": 20,
-                "OS_Crest_EL": 6,
-                "Seepage_Bottom": 2,
-                "Seepage_Side": 4,
-                "length": 200,
-                "w1": 200,
-                "w2": 200,
-                "side_slope_z": 3,
-                "bottom_slope": .5
+            "examples": {
+                "PondOption1": {
+                "summary": "Pond Option 1",
+                    "value": {
+                        "lat": 33.3946,
+                        "lon": -80.3474,
+                        "AEP": 4,
+                        "CNModificationMethod": "Merkel",
+                        "Area": 100.0,
+                        "Tc": 64.5,
+                        "RainfallDistributionCurve": "II",
+                        "PRF": 240,
+                        "CN": 67.3,
+                        "S": 4.86,
+                        "Ia": 0.97,
+                        "pondOption": 1,
+                        "pond_bottom_elev": 100,
+                        "Orif1_Coeff":.6,
+                        "Orif1_Dia": 6,
+                        "Orif1_CtrEL": .5,
+                        "Orif1_NumOpenings": 1,
+                        "Orif2_Coeff": .6,
+                        "Orif2_Dia": 6,
+                        "Orif2_CtrEL": 2,
+                        "Orif2_NumOpenings": 1,
+                        "Rec_Weir_Coeff": 3.3,
+                        "Rec_Weir_Ex": 1.5,
+                        "Rec_Weir_Length": 2,
+                        "Rec_WeirCrest_EL": 4,
+                        "Rec_Num_Weirs": 1,
+                        "OS_BCWeir_Coeff": 3,
+                        "OS_Weir_Ex": 1.5,
+                        "OS_Length": 20,
+                        "OS_Crest_EL": 6,
+                        "Seepage_Bottom": 2,
+                        "Seepage_Side": 4,
+                        "length": 200,
+                        "w1": 200,
+                        "w2": 200,
+                        "side_slope_z": 3,
+                        "bottom_slope": .5
+                    }
+                },
+                "PondOption2": {
+                    "summary": "Pond Option 2",
+                    "value": {
+                        "lat": 33.3946,
+                        "lon": -80.3474,
+                        "AEP": 4,
+                        "CNModificationMethod": "Merkel",
+                        "Area": 100.0,
+                        "Tc": 64.5,
+                        "RainfallDistributionCurve": "II",
+                        "PRF": 240,
+                        "CN": 67.3,
+                        "S": 4.86,
+                        "Ia": 0.97,
+                        "pondOption": 2,
+                        "pond_bottom_elev": 100,
+                        "Orif1_Coeff":.6,
+                        "Orif1_Dia": 6,
+                        "Orif1_CtrEL": .5,
+                        "Orif1_NumOpenings": 1,
+                        "Orif2_Coeff": .6,
+                        "Orif2_Dia": 6,
+                        "Orif2_CtrEL": 2,
+                        "Orif2_NumOpenings": 1,
+                        "Rec_Weir_Coeff": 3.3,
+                        "Rec_Weir_Ex": 1.5,
+                        "Rec_Weir_Length": 2,
+                        "Rec_WeirCrest_EL": 4,
+                        "Rec_Num_Weirs": 1,
+                        "OS_BCWeir_Coeff": 3,
+                        "OS_Weir_Ex": 1.5,
+                        "OS_Length": 20,
+                        "OS_Crest_EL": 6,
+                        "Seepage_Bottom": 2,
+                        "Seepage_Side": 4,
+                        "Elev_Area": [[100, 2000], [101,2100],[102,2200],[103,2400],[104, 2900],[105,3300],[106,3700],[107,4000],[108,4400],[109,4800]]
+                    }
+                }
             }
         }
 
@@ -840,9 +883,8 @@ def calculatemissingparametersSCSUH(request_body: CalculateMissingParametersSCSU
         raise HTTPException(status_code = 500, detail =  str(e))
     
 
-
 @app.post("/stormponds/")
-def stormponds(request_body: calculateStormPonds, response: Response):
+def stormponds(request_body: calculateStormPonds = Body(examples=calculateStormPonds.Config.schema_extra["examples"])):
 
     try: 
         runoff_and_ponding_results, pond_inflow_and_outflow_ordinates = calcStormPonds(

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 from fastapi import FastAPI, HTTPException, Response
-from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -478,21 +477,21 @@ class calculateStormPonds(BaseModel):
     S: float = Field(..., title="Watershed Retention", description="watershed Retention, S (float)", example="4.86")
     Ia: float = Field(..., title="Initial Abstraction", description="Initial Abstraction, Ia (float)", example="0.97")
     pondOption: int = Field(..., title="Pond Option", description="Pond Option, (int)", example="1")
-    pond_bottom_elev: float = Field(..., title="Bottom Elevation", description="Elevation of pond botton in feet (float)", example="100")
-    Orif1_Coeff: float = Field(..., title="Orfice 1 Coefficent", description="Coefficent of 1st stage circular orfice (float)", example=".60")
-    Orif1_Dia: float = Field(..., title="Orfice 1 Diameter", description="Diameter of 1st stage circular orfice in inches (float)", example="6.0")
-    Orif1_CtrEL: float = Field(..., title="Orfice 1 Centerline Elevation", description="Centerline elevation above pond bottom of 1st stage circular orfice in feet (float)", example=".5")
-    Orif1_NumOpenings: int = Field(..., title="Orfice 1 Number of Openings", description="Number of openings for 1st stage circulare orfice, (int)", example="1")
-    Orif2_Coeff: float = Field(..., title="Orfice 2 Coefficent", description="Coefficent of 2nd stage circular orfice (float)", example=".60")
-    Orif2_Dia: float = Field(..., title="Orfice 2 Diameter", description="Diameter of 2nd stage circular orfice in inches (float)", example="6.0")
-    Orif2_CtrEL: float = Field(..., title="Orfice 2 Centerline Elevation", description="Centerline elevation above pond bottom of 2nd stage circular orfice in feet (float)", example="2.0")
-    Orif2_NumOpenings: int = Field(..., title="Orfice 2 Number of Openings", description="Number of openings for 2nd stage circular orfice, (int)", example="1")
-    Rec_Weir_Coeff: float = Field(..., title="Weir Coefficent", description="Coefficent of 3rd stage rectangular weir (float)", example="3.30")
+    pond_bottom_elev: float = Field(..., title="Bottom Elevation", description="Elevation of pond bottom in feet (float)", example="100")
+    Orif1_Coeff: float = Field(..., title="Orifice 1 Coefficient", description="Coefficient of 1st stage circular orifice (float)", example=".60")
+    Orif1_Dia: float = Field(..., title="Orifice 1 Diameter", description="Diameter of 1st stage circular orifice in inches (float)", example="6.0")
+    Orif1_CtrEL: float = Field(..., title="Orifice 1 Centerline Elevation", description="Centerline elevation above pond bottom of 1st stage circular orifice in feet (float)", example=".5")
+    Orif1_NumOpenings: int = Field(..., title="Orifice 1 Number of Openings", description="Number of openings for 1st stage circular orifice, (int)", example="1")
+    Orif2_Coeff: float = Field(..., title="Orifice 2 Coefficient", description="Coefficient of 2nd stage circular orifice (float)", example=".60")
+    Orif2_Dia: float = Field(..., title="Orifice 2 Diameter", description="Diameter of 2nd stage circular orifice in inches (float)", example="6.0")
+    Orif2_CtrEL: float = Field(..., title="Orifice 2 Centerline Elevation", description="Centerline elevation above pond bottom of 2nd stage circular orifice in feet (float)", example="2.0")
+    Orif2_NumOpenings: int = Field(..., title="Orifice 2 Number of Openings", description="Number of openings for 2nd stage circular orifice, (int)", example="1")
+    Rec_Weir_Coeff: float = Field(..., title="Weir Coefficient", description="Coefficient of 3rd stage rectangular weir (float)", example="3.30")
     Rec_Weir_Ex: float = Field(..., title="Weir Exponent", description="Exponent of 3rd stage rectangular weir (float)", example="1.5")
     Rec_Weir_Length: float = Field(..., title="Weir Length", description="Length of 3rd stage rectangular weir in feet (float)", example="2.0")
     Rec_WeirCrest_EL: float = Field(..., title="Weir Crest Elevation", description="Crest elevation above pond bottom of 3rd stage rectangular weir in feet (float)", example="4.0")
-    Rec_Num_Wiers: int = Field(..., title="Number of Wiers", description="Number of weirs for 3rd stage rectangular weir, (int)", example="1")
-    OS_BCWeir_Coeff: float = Field(..., title="Broad-Crested Weir Coefficent", description="Broad-Crested weir coefficent of overflow spillway (float)", example="3.00")
+    Rec_Num_Weirs: int = Field(..., title="Number of Weirs", description="Number of weirs for 3rd stage rectangular weir, (int)", example="1")
+    OS_BCWeir_Coeff: float = Field(..., title="Broad-Crested Weir Coefficient", description="Broad-Crested weir coefficient of overflow spillway (float)", example="3.00")
     OS_Weir_Ex: float = Field(..., title="Weir Exponent", description="Exponent of  overflow spillway (float)", example="1.5")
     OS_Length: float = Field(..., title="Overflow Spillway Length", description="Length of overflow spillway in feet (float)", example="2.0")
     OS_Crest_EL: float = Field(..., title="Overflow Crest Elevation", description="Crest elevation above pond bottom of overflow spillway in feet (float)", example="6.0") 
@@ -533,7 +532,7 @@ class calculateStormPonds(BaseModel):
                 "Rec_Weir_Ex": 1.5,
                 "Rec_Weir_Length": 2,
                 "Rec_WeirCrest_EL": 4,
-                "Rec_Num_Wiers": 1,
+                "Rec_Num_Weirs": 1,
                 "OS_BCWeir_Coeff": 3,
                 "OS_Weir_Ex": 1.5,
                 "OS_Length": 20,
@@ -872,7 +871,7 @@ def stormponds(request_body: calculateStormPonds, response: Response):
             request_body.Rec_Weir_Ex,
             request_body.Rec_Weir_Length,
             request_body.Rec_WeirCrest_EL,
-            request_body.Rec_Num_Wiers,
+            request_body.Rec_Num_Weirs,
             request_body.OS_BCWeir_Coeff,
             request_body.OS_Weir_Ex,
             request_body.OS_Length,

--- a/main.py
+++ b/main.py
@@ -882,7 +882,8 @@ def stormponds(request_body: calculateStormPonds, response: Response):
             request_body.w1,
             request_body.w2,
             request_body.side_slope_z,
-            request_body.bottom_slope
+            request_body.bottom_slope,
+            request_body.Elev_Area
         )
         return {
             "runoff_and_ponding_results": runoff_and_ponding_results,

--- a/main.py
+++ b/main.py
@@ -7,12 +7,13 @@ from SC_Synthetic_UH_Method import weightedCurveNumber, PRFData, rainfallData, r
 from Bohman_Method_1989 import computeRuralFloodHydrographBohman1989
 from Bohman_Method_1992 import getRI2, computeUrbanFloodHydrographBohman1992
 from Tc_Calculator import lagTimeMethodTimeOfConcentration, travelTimeMethodTimeOfConcentration
+from Storm_Ponds import calcponds
 
 app = FastAPI(
     title='SC Runoff Modeling Services',
-    root_path='/local/scrunoffservices'
+    #root_path='/local/scrunoffservices'
     # To run locally use
-    # root_path=''
+    root_path=''
     # To run in production use
     #    root_path='/local/scrunoffservices'
 )
@@ -753,3 +754,19 @@ def calculatemissingparametersSCSUH(request_body: CalculateMissingParametersSCSU
 
     except Exception as e:
         raise HTTPException(status_code = 500, detail =  str(e))
+    
+
+
+@app.post("/ponds/")
+def ponds():
+
+    try: 
+        runoff_and_ponding_results, pond_inflow_and_outflow_ordinates = calcponds()
+        return {
+            "runoff_and_ponding_results": runoff_and_ponding_results,
+            "pond_inflow_and_outflow_ordinates": pond_inflow_and_outflow_ordinates        
+        }        
+
+    except Exception as e:
+        raise HTTPException(status_code = 500, detail =  str(e))
+

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ from Storm_Ponds import calcStormPonds
 
 app = FastAPI(
     title='SC Runoff Modeling Services',
-    #root_path='/local/scrunoffservices'
+    root_path='/local/scrunoffservices'
     # To run locally use
-    root_path=''
+    # root_path=''
     # To run in production use
     #    root_path='/local/scrunoffservices'
 )

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from SC_Synthetic_UH_Method import weightedCurveNumber, PRFData, rainfallData, r
 from Bohman_Method_1989 import computeRuralFloodHydrographBohman1989
 from Bohman_Method_1992 import getRI2, computeUrbanFloodHydrographBohman1992
 from Tc_Calculator import lagTimeMethodTimeOfConcentration, travelTimeMethodTimeOfConcentration
-from Storm_Ponds import calcponds
+from Storm_Ponds import calcStormPonds
 
 app = FastAPI(
     title='SC Runoff Modeling Services',
@@ -464,6 +464,91 @@ class CalculateMissingParametersSCSUH(BaseModel):
                     ]
             }
         }
+
+class calculateStormPonds(BaseModel):
+    lat: float = Field(..., title="latitude", description="latitude coordinate of the drainage point (float)", example="33.3946")
+    lon: float = Field(..., title="longitude", description="longitude coordinate of the drainage point (float)", example="-80.3474")
+    AEP: float = Field(..., title="Annual Exceedance Probability", description="Annual Exceedance Probability (%); options are 100 50, 20, 10, 4, 2, 1, which correspond to 1-yr, 2-yr, 5-yr, 10-yr, 25-yr, 50-yr, and 100-yr storms (int)", example="4")
+    CNModificationMethod: str = Field(..., title="Curve Number Modification Method", description="method used to modify the Curve Number; options are 'McCuen' or 'Merkel' (string)", example="Merkel")
+    Area: float = Field(..., title="Area", description="drainage area of delineated basin (float)", example="100.0")
+    Tc: float = Field(..., title="Time of Concentration", description="Time of Concentration as computed by Travel Time Method or Lag Time Equation (float)", example="64.5")
+    RainfallDistributionCurve: str = Field(..., title="Rainfall Distribution Curve", description="rainfall distribution curve letter; options are 'II', 'III', 'A', 'B', 'C', 'D' (string)", example="II")
+    PRF: float = Field(..., title="Peak Rate Factor (float)", description="", example="240")
+    CN: float = Field(..., title="Curve Number", description="weighted Curve Number (float)", example="67.3")
+    S: float = Field(..., title="Watershed Retention", description="watershed Retention, S (float)", example="4.86")
+    Ia: float = Field(..., title="Initial Abstraction", description="Initial Abstraction, Ia (float)", example="0.97")
+    pondOption: int = Field(..., title="Pond Option", description="Pond Option, (int)", example="1")
+    pond_bottom_elev: float = Field(..., title="Bottom Elevation", description="Elevation of pond botton in feet (float)", example="100")
+    Orif1_Coeff: float = Field(..., title="Orfice 1 Coefficent", description="Coefficent of 1st stage circular orfice (float)", example=".60")
+    Orif1_Dia: float = Field(..., title="Orfice 1 Diameter", description="Diameter of 1st stage circular orfice in inches (float)", example="6.0")
+    Orif1_CtrEL: float = Field(..., title="Orfice 1 Centerline Elevation", description="Centerline elevation above pond bottom of 1st stage circular orfice in feet (float)", example=".5")
+    Orif1_NumOpenings: int = Field(..., title="Orfice 1 Number of Openings", description="Number of openings for 1st stage circulare orfice, (int)", example="1")
+    Orif2_Coeff: float = Field(..., title="Orfice 2 Coefficent", description="Coefficent of 2nd stage circular orfice (float)", example=".60")
+    Orif2_Dia: float = Field(..., title="Orfice 2 Diameter", description="Diameter of 2nd stage circular orfice in inches (float)", example="6.0")
+    Orif2_CtrEL: float = Field(..., title="Orfice 2 Centerline Elevation", description="Centerline elevation above pond bottom of 2nd stage circular orfice in feet (float)", example="2.0")
+    Orif2_NumOpenings: int = Field(..., title="Orfice 2 Number of Openings", description="Number of openings for 2nd stage circular orfice, (int)", example="1")
+    Rec_Weir_Coeff: float = Field(..., title="Weir Coefficent", description="Coefficent of 3rd stage rectangular weir (float)", example="3.30")
+    Rec_Weir_Ex: float = Field(..., title="Weir Exponent", description="Exponent of 3rd stage rectangular weir (float)", example="1.5")
+    Rec_Weir_Length: float = Field(..., title="Weir Length", description="Length of 3rd stage rectangular weir in feet (float)", example="2.0")
+    Rec_WeirCrest_EL: float = Field(..., title="Weir Crest Elevation", description="Crest elevation above pond bottom of 3rd stage rectangular weir in feet (float)", example="4.0")
+    Rec_Num_Wiers: int = Field(..., title="Number of Wiers", description="Number of weirs for 3rd stage rectangular weir, (int)", example="1")
+    OS_BCWeir_Coeff: float = Field(..., title="Broad-Crested Weir Coefficent", description="Broad-Crested weir coefficent of overflow spillway (float)", example="3.00")
+    OS_Weir_Ex: float = Field(..., title="Weir Exponent", description="Exponent of  overflow spillway (float)", example="1.5")
+    OS_Length: float = Field(..., title="Overflow Spillway Length", description="Length of overflow spillway in feet (float)", example="2.0")
+    OS_Crest_EL: float = Field(..., title="Overflow Crest Elevation", description="Crest elevation above pond bottom of overflow spillway in feet (float)", example="6.0") 
+    Seepage_Bottom: float = Field(..., title="Bottom Seepage", description="Seepage through pond bottom in in/hr, (float)", example="2.0")
+    Seepage_Side: float = Field(..., title="Side Slope Seepage", description="Seepage through side slopes in in/hr, (float)", example="4.0")
+    length: float = Field(default=None, title="Length of Inverted Quadrilateral Frustum", description="Length of inverted quadrilateral frustum in feet, for pond option 1, (float)", example="200")
+    w1: float = Field(default=None, title="W1 Inverted Quadrilateral Frustum", description="W1 of inverted quadrilateral frustum in feet, for pond option 1, (float)", example="200")
+    w2: float = Field(default=None, title="W2 Inverted Quadrilateral Frustum", description="W2 of inverted quadrilateral frustum in feet, for pond option 1, (float)", example="200")
+    side_slope_z: float = Field(default=None, title="Side Slope of Inverted Quadrilateral Frustum", description="Side slope z of inverted quadrilateral frustum, for pond option 1, (float)", example="3.0")
+    bottom_slope: float = Field(default=None, title="Bottom Slope of Inverted Quadrilateral Frustum", description="Bottom slope of inverted quadrilateral frustum in %, for pond option 1, (float)", example=".5")
+    Elev_Area: list = Field(default=None, title="Elevation vs Surface Area", description="Elevation in ft-MSL vs Surface Area in sq ft, for pond option 2, (float)", example="[[100, 2000], [101,2100],[102,2200],[103,2400],[104, 2900],[105,3300],[106,3700],[107,4000],[108,4400],[109,4800]]")
+    
+    class Config:
+        schema_extra = {
+            "example": {
+                "lat": 33.3946,
+                "lon": -80.3474,
+                "AEP": 4,
+                "CNModificationMethod": "Merkel",
+                "Area": 100.0,
+                "Tc": 64.5,
+                "RainfallDistributionCurve": "II",
+                "PRF": 240,
+                "CN": 67.3,
+                "S": 4.86,
+                "Ia": 0.97,
+                "pondOption": 1,
+                "pond_bottom_elev": 100,
+                "Orif1_Coeff":.6,
+                "Orif1_Dia": 6,
+                "Orif1_CtrEL": .5,
+                "Orif1_NumOpenings": 1,
+                "Orif2_Coeff": .6,
+                "Orif2_Dia": 6,
+                "Orif2_CtrEL": 2,
+                "Orif2_NumOpenings": 1,
+                "Rec_Weir_Coeff": 3.3,
+                "Rec_Weir_Ex": 1.5,
+                "Rec_Weir_Length": 2,
+                "Rec_WeirCrest_EL": 4,
+                "Rec_Num_Wiers": 1,
+                "OS_BCWeir_Coeff": 3,
+                "OS_Weir_Ex": 1.5,
+                "OS_Length": 20,
+                "OS_Crest_EL": 6,
+                "Seepage_Bottom": 2,
+                "Seepage_Side": 4,
+                "length": 200,
+                "w1": 200,
+                "w2": 200,
+                "side_slope_z": 3,
+                "bottom_slope": .5
+            }
+        }
+
+
 ######
 ##
 ## API Endpoints
@@ -757,11 +842,49 @@ def calculatemissingparametersSCSUH(request_body: CalculateMissingParametersSCSU
     
 
 
-@app.post("/ponds/")
-def ponds():
+@app.post("/stormponds/")
+def stormponds(request_body: calculateStormPonds, response: Response):
 
     try: 
-        runoff_and_ponding_results, pond_inflow_and_outflow_ordinates = calcponds()
+        runoff_and_ponding_results, pond_inflow_and_outflow_ordinates = calcStormPonds(
+            request_body.lat,
+            request_body.lon,
+            request_body.AEP,
+            request_body.CNModificationMethod,
+            request_body.Area,
+            request_body.Tc,
+            request_body.RainfallDistributionCurve,
+            request_body.PRF,
+            request_body.CN,
+            request_body.S,
+            request_body.Ia,
+            request_body.pondOption,
+            request_body.pond_bottom_elev,
+            request_body.Orif1_Coeff,
+            request_body.Orif1_Dia,
+            request_body.Orif1_CtrEL,
+            request_body.Orif1_NumOpenings,
+            request_body.Orif2_Coeff,
+            request_body.Orif2_Dia,
+            request_body.Orif2_CtrEL,
+            request_body.Orif2_NumOpenings,
+            request_body.Rec_Weir_Coeff,
+            request_body.Rec_Weir_Ex,
+            request_body.Rec_Weir_Length,
+            request_body.Rec_WeirCrest_EL,
+            request_body.Rec_Num_Wiers,
+            request_body.OS_BCWeir_Coeff,
+            request_body.OS_Weir_Ex,
+            request_body.OS_Length,
+            request_body.OS_Crest_EL,
+            request_body.Seepage_Bottom,
+            request_body.Seepage_Side,
+            request_body.length,
+            request_body.w1,
+            request_body.w2,
+            request_body.side_slope_z,
+            request_body.bottom_slope
+        )
         return {
             "runoff_and_ponding_results": runoff_and_ponding_results,
             "pond_inflow_and_outflow_ordinates": pond_inflow_and_outflow_ordinates        


### PR DESCRIPTION
Incorporate storm ponds. 
Inputs are everything needed for the scsyntheticunithydrograph endpoint along with inputs found on Design Storm Pond Results tab. 
Results are split into two objects: runoff_and_ponding_results and pond_inflow_and_outflow_ordinates. The runoff_and_ponding_results contains values found in the 'Runoff and Pond Routing Results for D-Hour Design Storm Rainfall Events' table, along with max depth which is found in the pond_x hr tabs. pond_inflow_and_outflow_ordinates contains all values in the D-Hour Storm Pond Routing Inflow and Outflow Hydrograph Ordinates table. 

Uses following tabs in spreadsheet for calculation:
- Design Storm Pond Results
- 2S_Dt+Q
- Y-S (1) & Y-S (2)
- Y-Q (1) & Y-Q (2)
- Pond_1 hr, Pond_2 hr, Pond_3 hr, Pond_6 hr, Pond_12 hr, Pond_24 hr

Results are located in following tabs:
- D-hr Storm Pond Routing Results